### PR TITLE
削除機能(deleteの動作とリダイレクト処理)の実装

### DIFF
--- a/app/controllers/cooking_repertoires_controller.rb
+++ b/app/controllers/cooking_repertoires_controller.rb
@@ -19,12 +19,6 @@ class CookingRepertoiresController < ApplicationController
     end
   end
 
-  def show
-  end
-
-  def edit
-  end
-
   def update
     if @cooking_repertoire.update(cooking_repertoire_params)
       redirect_to :root, notice: t('.edited_repertoire', {name: @cooking_repertoire.name})

--- a/app/controllers/cooking_repertoires_controller.rb
+++ b/app/controllers/cooking_repertoires_controller.rb
@@ -34,6 +34,11 @@ class CookingRepertoiresController < ApplicationController
     end
   end
 
+  def destroy
+    @cooking_repertoire = CookingRepertoire.find(params[:id])
+    redirect_to :root, notice: t('.deleted_repertoire', {name: @cooking_repertoire.name})
+  end
+
   private
 
   def cooking_repertoire_params

--- a/app/controllers/cooking_repertoires_controller.rb
+++ b/app/controllers/cooking_repertoires_controller.rb
@@ -1,4 +1,6 @@
 class CookingRepertoiresController < ApplicationController
+  before_action :find_repertoire, only: [:show, :edit, :update, :destroy]
+
   def index
     @cooking_repertoires = CookingRepertoire.all
   end
@@ -18,15 +20,12 @@ class CookingRepertoiresController < ApplicationController
   end
 
   def show
-    @cooking_repertoire = CookingRepertoire.find(params[:id])
   end
 
   def edit
-    @cooking_repertoire = CookingRepertoire.find(params[:id])
   end
 
   def update
-    @cooking_repertoire = CookingRepertoire.find(params[:id])
     if @cooking_repertoire.update(cooking_repertoire_params)
       redirect_to :root, notice: t('.edited_repertoire', {name: @cooking_repertoire.name})
     else
@@ -35,7 +34,6 @@ class CookingRepertoiresController < ApplicationController
   end
 
   def destroy
-    @cooking_repertoire = CookingRepertoire.find(params[:id])
     redirect_to :root, notice: t('.deleted_repertoire', {name: @cooking_repertoire.name})
   end
 
@@ -43,5 +41,9 @@ class CookingRepertoiresController < ApplicationController
 
   def cooking_repertoire_params
     params.require(:cooking_repertoire).permit(:name)
+  end
+
+  def find_repertoire
+    @cooking_repertoire = CookingRepertoire.find(params[:id])
   end
 end

--- a/app/views/cooking_repertoires/show.slim
+++ b/app/views/cooking_repertoires/show.slim
@@ -13,4 +13,6 @@ li
   = @cooking_repertoire.updated_at.to_s(:datetime_jp)
 = link_to (t '.edit'), edit_cooking_repertoire_path
 <br>
+= link_to (t '.delete'), @cooking_repertoire, method: :delete, data: { confirm: (t '.delete_confirmation', {name: @cooking_repertoire.name}) }
+<br>
 = link_to (t '.back_list'), root_path

--- a/app/views/cooking_repertoires/show.slim
+++ b/app/views/cooking_repertoires/show.slim
@@ -12,7 +12,7 @@ li
   = t 'attributes.updated_at'
   = @cooking_repertoire.updated_at.to_s(:datetime_jp)
 = link_to (t '.edit'), edit_cooking_repertoire_path
-<br>
+br
 = link_to (t '.delete'), @cooking_repertoire, method: :delete, data: { confirm: (t '.delete_confirmation', {name: @cooking_repertoire.name}) }
-<br>
+br
 = link_to (t '.back_list'), root_path

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,3 +4,5 @@ ja:
       added_repertoire: レパートリーに%{name}を追加しました。
     update:
       edited_repertoire: レパートリー名を%{name}に編集しました。
+    destroy:
+      deleted_repertoire: レパートリー名「%{name}」を削除しました。

--- a/config/locales/views/cooking_repertoires/ja.yml
+++ b/config/locales/views/cooking_repertoires/ja.yml
@@ -8,6 +8,8 @@ ja:
     show: 
       title: レパートリーの詳細
       back_list: 一覧へ戻る
+      delete_confirmation: レパートリー名「%{name}」を削除します。よろしいですか？
       edit: 編集
+      delete: 削除
     edit:
       title: レパートリー名編集

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  resources :cooking_repertoires, only:[:index, :new, :create, :show, :edit, :update]
+  resources :cooking_repertoires, only:[:index, :new, :create, :show, :edit, :update, :destroy]
   root to: 'cooking_repertoires#index'
 end


### PR DESCRIPTION
closed #6 
# やったこと
1.詳細画面い削除ボタンを実装
2.destroyアクションを実装(削除後一覧表示にリダイレクト)※実際にデータを削除はしない

# 実行結果
**httpリクエスト**
![スクリーンショット 2020-04-17 9 53 59](https://user-images.githubusercontent.com/62975075/79520311-6c12b500-8091-11ea-94c4-74b7d04bfcf2.png)

**実行画面**
<img width="827" alt="スクリーンショット 2020-04-17 9 52 51" src="https://user-images.githubusercontent.com/62975075/79520264-4ab1c900-8091-11ea-818d-2c8d4688cb92.png">

<img width="336" alt="スクリーンショット 2020-04-17 9 53 03" src="https://user-images.githubusercontent.com/62975075/79520266-4d142300-8091-11ea-9021-9f440eee6f66.png">
