### PR TITLE
レパートリー名の新規登録時にタグの一覧を表示させて同時に中間テーブルにデータを保存する

### DIFF
--- a/app/controllers/cooking_repertoires_controller.rb
+++ b/app/controllers/cooking_repertoires_controller.rb
@@ -1,5 +1,6 @@
 class CookingRepertoiresController < ApplicationController
   before_action :find_repertoire, only: [:show, :edit, :update, :destroy]
+  before_action :list_tags, only: [:new, :create]
 
   def index
     @cooking_repertoires = CookingRepertoire.all
@@ -7,12 +8,11 @@ class CookingRepertoiresController < ApplicationController
 
   def new
     @cooking_repertoire = CookingRepertoire.new
-    @tags = Tag.where.not(name: t('.erase'))
   end
 
   def create
     @cooking_repertoire = CookingRepertoire.new(cooking_repertoire_params)
-
+    
     if @cooking_repertoire.save
       redirect_to :root, notice: t('.added_repertoire', { name: @cooking_repertoire.name })
     else
@@ -40,5 +40,9 @@ class CookingRepertoiresController < ApplicationController
 
   def find_repertoire
     @cooking_repertoire = CookingRepertoire.find(params[:id])
+  end
+
+  def list_tags
+    @tags = Tag.where.not(name: t('.erase'))
   end
 end

--- a/app/controllers/cooking_repertoires_controller.rb
+++ b/app/controllers/cooking_repertoires_controller.rb
@@ -12,7 +12,7 @@ class CookingRepertoiresController < ApplicationController
 
   def create
     @cooking_repertoire = CookingRepertoire.new(cooking_repertoire_params)
-    
+
     if @cooking_repertoire.save
       redirect_to :root, notice: t('.added_repertoire', { name: @cooking_repertoire.name })
     else

--- a/app/controllers/cooking_repertoires_controller.rb
+++ b/app/controllers/cooking_repertoires_controller.rb
@@ -7,6 +7,7 @@ class CookingRepertoiresController < ApplicationController
 
   def new
     @cooking_repertoire = CookingRepertoire.new
+    @tags = Tag.where.not(name: t('.erase'))
   end
 
   def create
@@ -34,7 +35,7 @@ class CookingRepertoiresController < ApplicationController
   private
 
   def cooking_repertoire_params
-    params.require(:cooking_repertoire).permit(:name)
+    params.require(:cooking_repertoire).permit(:name, { tag_ids: [] })
   end
 
   def find_repertoire

--- a/app/models/cooking_repertoire.rb
+++ b/app/models/cooking_repertoire.rb
@@ -1,3 +1,7 @@
 class CookingRepertoire < ApplicationRecord
   validates :name, presence: true, uniqueness: true
+
+  has_many :cooking_repertoire_tags
+  has_many :tags, through: :cooking_repertoire_tags
+  accepts_nested_attributes_for :cooking_repertoire_tags
 end

--- a/app/models/cooking_repertoire_tag.rb
+++ b/app/models/cooking_repertoire_tag.rb
@@ -1,0 +1,4 @@
+class CookingRepertoireTag < ApplicationRecord
+  belongs_to :cooking_repertoire
+  belongs_to :tag
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,2 +1,4 @@
 class Tag < ApplicationRecord
+  has_many :cooking_repertoire_tags
+  has_many :cooking_repertoires, through: :cooking_repertoire_tags
 end

--- a/app/views/cooking_repertoires/_form.slim
+++ b/app/views/cooking_repertoires/_form.slim
@@ -3,5 +3,9 @@
     ul
       - cooking_repertoire.errors.full_messages.each do |message|
         li = message
+  = form.label :name
   = form.text_field :name
+  br
+  = form.collection_check_boxes :tag_ids, tags, :id, :name
+  br
   = form.submit

--- a/app/views/cooking_repertoires/_form.slim
+++ b/app/views/cooking_repertoires/_form.slim
@@ -4,8 +4,6 @@
       - cooking_repertoire.errors.full_messages.each do |message|
         li = message
   = form.label :name
-  = form.text_field :name
-  br
-  = form.collection_check_boxes :tag_ids, tags, :id, :name
-  br
+  p = form.text_field :name
+  p = form.collection_check_boxes :tag_ids, tags, :id, :name
   = form.submit

--- a/app/views/cooking_repertoires/_form.slim
+++ b/app/views/cooking_repertoires/_form.slim
@@ -4,6 +4,6 @@
       - cooking_repertoire.errors.full_messages.each do |message|
         li = message
   = form.label :name
-  p = form.text_field :name
-  p = form.collection_check_boxes :tag_ids, tags, :id, :name
+  = form.text_field :name
+  div = form.collection_check_boxes :tag_ids, tags, :id, :name
   = form.submit

--- a/app/views/cooking_repertoires/new.slim
+++ b/app/views/cooking_repertoires/new.slim
@@ -1,2 +1,2 @@
 h1 = t '.title'
-= render 'form', cooking_repertoire: @cooking_repertoire
+= render 'form', cooking_repertoire: @cooking_repertoire, tags: @tags

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,3 +6,5 @@ ja:
       edited_repertoire: レパートリー名を%{name}に編集しました。
     destroy:
       deleted_repertoire: レパートリー名「%{name}」を削除しました。
+    new:
+      erase: 消去

--- a/db/migrate/20200422063725_create_cooking_repertoire_tags.rb
+++ b/db/migrate/20200422063725_create_cooking_repertoire_tags.rb
@@ -1,0 +1,10 @@
+class CreateCookingRepertoireTags < ActiveRecord::Migration[6.0]
+  def change
+    create_table :cooking_repertoire_tags do |t|
+      t.references :cooking_repertoire, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_22_030228) do
+ActiveRecord::Schema.define(version: 2020_04_22_063725) do
+
+  create_table "cooking_repertoire_tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "cooking_repertoire_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["cooking_repertoire_id"], name: "index_cooking_repertoire_tags_on_cooking_repertoire_id"
+    t.index ["tag_id"], name: "index_cooking_repertoire_tags_on_tag_id"
+  end
 
   create_table "cooking_repertoires", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -26,4 +35,6 @@ ActiveRecord::Schema.define(version: 2020_04_22_030228) do
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
+  add_foreign_key "cooking_repertoire_tags", "cooking_repertoires"
+  add_foreign_key "cooking_repertoire_tags", "tags"
 end


### PR DESCRIPTION
closed #16 
# やったこと
1.新規登録画面にtagsの一覧をチェックボックスで表示させる
2.レパートリー名の保存と同時に中間テーブルにも保存する

# 実行結果
<img width="1037" alt="スクリーンショット 2020-04-23 9 50 41" src="https://user-images.githubusercontent.com/62975075/80047269-f18ddd80-8547-11ea-8774-8f84d28268d3.png">

___

<img width="293" alt="スクリーンショット 2020-04-23 9 51 30" src="https://user-images.githubusercontent.com/62975075/80047312-11bd9c80-8548-11ea-914e-c7af8edfaedf.png">

# ログ
![スクリーンショット 2020-04-23 9 55 55](https://user-images.githubusercontent.com/62975075/80047544-ae803a00-8548-11ea-8439-d99bef3d1f39.png)



# データベース情報
**cooking_repertoiresテーブル**
<img width="556" alt="スクリーンショット 2020-04-23 9 54 52" src="https://user-images.githubusercontent.com/62975075/80047478-81cc2280-8548-11ea-8b92-91a3db4182b2.png">

___

**中間テーブル**
<img width="609" alt="スクリーンショット 2020-04-23 9 52 57" src="https://user-images.githubusercontent.com/62975075/80047487-85f84000-8548-11ea-9499-0bc4f201cc32.png">
