### PR TITLE
レパートリー名の編集時にタグ一覧を追加してデータを更新する

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ Style/SymbolArray:
 
 # 1行あたりの文字数を100文字にする
 Layout/LineLength:
-  Max: 100
+  Max: 120
 
 # rubocop起動時に警告が出たのでtrue or falseの選択
 Layout/SpaceAroundMethodCallOperator:

--- a/app/controllers/cooking_repertoires_controller.rb
+++ b/app/controllers/cooking_repertoires_controller.rb
@@ -43,6 +43,6 @@ class CookingRepertoiresController < ApplicationController
   end
 
   def list_tags
-    @tags = Tag.where.not(name: t('.erase'))
+    @tags = Tag.except_erase
   end
 end

--- a/app/controllers/cooking_repertoires_controller.rb
+++ b/app/controllers/cooking_repertoires_controller.rb
@@ -1,6 +1,6 @@
 class CookingRepertoiresController < ApplicationController
   before_action :find_repertoire, only: [:show, :edit, :update, :destroy]
-  before_action :list_tags, only: [:new, :create]
+  before_action :list_tags, only: [:new, :create, :edit, :update]
 
   def index
     @cooking_repertoires = CookingRepertoire.all

--- a/app/controllers/cooking_repertoires_controller.rb
+++ b/app/controllers/cooking_repertoires_controller.rb
@@ -1,6 +1,5 @@
 class CookingRepertoiresController < ApplicationController
   before_action :find_repertoire, only: [:show, :edit, :update, :destroy]
-  before_action :list_tags, only: [:new, :create, :edit, :update]
 
   def index
     @cooking_repertoires = CookingRepertoire.all
@@ -8,10 +7,12 @@ class CookingRepertoiresController < ApplicationController
 
   def new
     @cooking_repertoire = CookingRepertoire.new
+    @tags = Tag.valid_except_conditions
   end
 
   def create
     @cooking_repertoire = CookingRepertoire.new(cooking_repertoire_params)
+    @tags = Tag.valid_except_conditions
 
     if @cooking_repertoire.save
       redirect_to :root, notice: t('.added_repertoire', { name: @cooking_repertoire.name })
@@ -20,7 +21,13 @@ class CookingRepertoiresController < ApplicationController
     end
   end
 
+  def edit
+    @tags = Tag.valid_except_conditions
+  end
+
   def update
+    @tags = Tag.valid_except_conditions
+
     if @cooking_repertoire.update(cooking_repertoire_params)
       redirect_to :root, notice: t('.edited_repertoire', { name: @cooking_repertoire.name })
     else
@@ -40,9 +47,5 @@ class CookingRepertoiresController < ApplicationController
 
   def find_repertoire
     @cooking_repertoire = CookingRepertoire.find(params[:id])
-  end
-
-  def list_tags
-    @tags = Tag.except_erase
   end
 end

--- a/app/controllers/cooking_repertoires_controller.rb
+++ b/app/controllers/cooking_repertoires_controller.rb
@@ -7,12 +7,12 @@ class CookingRepertoiresController < ApplicationController
 
   def new
     @cooking_repertoire = CookingRepertoire.new
-    @tags = Tag.valid_except_conditions
+    @tags = Tag.valid
   end
 
   def create
     @cooking_repertoire = CookingRepertoire.new(cooking_repertoire_params)
-    @tags = Tag.valid_except_conditions
+    @tags = Tag.valid
 
     if @cooking_repertoire.save
       redirect_to :root, notice: t('.added_repertoire', { name: @cooking_repertoire.name })
@@ -22,11 +22,11 @@ class CookingRepertoiresController < ApplicationController
   end
 
   def edit
-    @tags = Tag.valid_except_conditions
+    @tags = Tag.valid
   end
 
   def update
-    @tags = Tag.valid_except_conditions
+    @tags = Tag.valid
 
     if @cooking_repertoire.update(cooking_repertoire_params)
       redirect_to :root, notice: t('.edited_repertoire', { name: @cooking_repertoire.name })

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -2,5 +2,5 @@ class Tag < ApplicationRecord
   has_many :cooking_repertoire_tags
   has_many :cooking_repertoires, through: :cooking_repertoire_tags
 
-  scope :valid_except_conditions, -> { where.not(name: I18n.t('activerecord.attributes.tag.erase')) }
+  scope :valid, -> { where.not(name: I18n.t('activerecord.attributes.tag.erase')) }
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,6 @@
 class Tag < ApplicationRecord
   has_many :cooking_repertoire_tags
   has_many :cooking_repertoires, through: :cooking_repertoire_tags
+
+  scope :except_erase, -> { where.not(name: I18n.t('activerecord.attributes.tag.erase')) }
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -2,5 +2,5 @@ class Tag < ApplicationRecord
   has_many :cooking_repertoire_tags
   has_many :cooking_repertoires, through: :cooking_repertoire_tags
 
-  scope :except_erase, -> { where.not(name: I18n.t('activerecord.attributes.tag.erase')) }
+  scope :valid_except_conditions, -> { where.not(name: I18n.t('activerecord.attributes.tag.erase')) }
 end

--- a/app/views/cooking_repertoires/edit.slim
+++ b/app/views/cooking_repertoires/edit.slim
@@ -1,2 +1,2 @@
 h1 = t '.title'
-= render 'form', cooking_repertoire: @cooking_repertoire
+= render 'form', cooking_repertoire: @cooking_repertoire, tags: @tags

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,4 +7,5 @@ ja:
     destroy:
       deleted_repertoire: レパートリー名「%{name}」を削除しました。
     new:
+    edit:
       erase: 消去

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -2,10 +2,13 @@ ja:
   activerecord:
     models:
       cooking_repertoire:
+      tag:
     attributes:
       cooking_repertoire:
         id: 'ID: '
         name: 'レパートリー名: '
+      tag:
+        erase: 消去
   attributes:
       created_at: '登録日時: '
       updated_at: '更新日時: '


### PR DESCRIPTION
closed #17 
# やったこと
1.edit.slim内でtagsのインスタンス変数をローカル変数に変更する処理を記述する
2.レパートリー名の編集画面でタグの情報の更新する

# 実行結果
<img width="1044" alt="スクリーンショット 2020-04-23 15 10 38" src="https://user-images.githubusercontent.com/62975075/80066075-3892c780-8576-11ea-8254-50e0601a744f.png">

___

<img width="358" alt="スクリーンショット 2020-04-23 15 21 59" src="https://user-images.githubusercontent.com/62975075/80066091-40526c00-8576-11ea-8dff-1e846bd071b4.png">

___

# ログ
![スクリーンショット 2020-04-23 15 12 32](https://user-images.githubusercontent.com/62975075/80066138-56602c80-8576-11ea-9825-14faa237a31a.png)

___

# データベース情報
**cooking_repertoiresテーブル**
<img width="553" alt="スクリーンショット 2020-04-23 15 23 48" src="https://user-images.githubusercontent.com/62975075/80066221-85769e00-8576-11ea-8b59-fc6536167fa3.png">

___

**中間テーブル**
<img width="266" alt="スクリーンショット 2020-04-23 15 23 38" src="https://user-images.githubusercontent.com/62975075/80066247-8dced900-8576-11ea-81d8-66250f03c6f2.png">

___

**tagsテーブル**
<img width="521" alt="スクリーンショット 2020-04-23 15 25 29" src="https://user-images.githubusercontent.com/62975075/80066346-b6ef6980-8576-11ea-9dda-ae237474c4cb.png">
