### PR TITLE
レパートリーの詳細にレパートリー名に関連するタグを表示する

### DIFF
--- a/app/views/cooking_repertoires/show.slim
+++ b/app/views/cooking_repertoires/show.slim
@@ -1,23 +1,23 @@
 h1 = t '.title'
 li
-  = t 'activerecord.attributes.cooking_repertoire.id'
+  = CookingRepertoire.human_attribute_name(:id)
   = @cooking_repertoire.id
 li
-  = t 'activerecord.attributes.cooking_repertoire.name'
+  = CookingRepertoire.human_attribute_name(:name)
   = @cooking_repertoire.name
 li
-  = t 'activerecord.attributes.cooking_repertoire.tag'
-  - @cooking_repertoire.cooking_repertoire_tags.each_with_index do |cooking_repertoire_tag, index|
-    - if index == @cooking_repertoire.cooking_repertoire_tags.size - 1
+  = CookingRepertoire.human_attribute_name(:tag)
+  - @cooking_repertoire.cooking_repertoire_tags.each.with_index(1) do |cooking_repertoire_tag, index|
+    - if index == @cooking_repertoire.cooking_repertoire_tags.size
       = cooking_repertoire_tag.tag.name
     - else
       = "#{cooking_repertoire_tag.tag.name}, "
 li
-  = t 'attributes.created_at'
+  = CookingRepertoire.human_attribute_name(:created_at)
   = @cooking_repertoire.created_at.to_s(:datetime_jp)
 li
-  = t 'attributes.updated_at'
+  = CookingRepertoire.human_attribute_name(:updated_at)
   = @cooking_repertoire.updated_at.to_s(:datetime_jp)
-div = link_to (t '.edit'), edit_cooking_repertoire_path
-div = link_to (t '.delete'), @cooking_repertoire, method: :delete, data: { confirm: (t '.delete_confirmation', {name: @cooking_repertoire.name}) }
-div = link_to (t '.back_list'), root_path
+div = link_to t('.edit'), edit_cooking_repertoire_path
+div = link_to t('.delete'), @cooking_repertoire, method: :delete, data: { confirm: (t '.delete_confirmation', {name: @cooking_repertoire.name}) }
+div = link_to t('.back_list'), root_path

--- a/app/views/cooking_repertoires/show.slim
+++ b/app/views/cooking_repertoires/show.slim
@@ -6,13 +6,18 @@ li
   = t 'activerecord.attributes.cooking_repertoire.name'
   = @cooking_repertoire.name
 li
+  = t 'activerecord.attributes.cooking_repertoire.tag'
+  - @cooking_repertoire.cooking_repertoire_tags.each_with_index do |cooking_repertoire_tag, index|
+    - if index == @cooking_repertoire.cooking_repertoire_tags.size - 1
+      = cooking_repertoire_tag.tag.name
+    - else
+      = "#{cooking_repertoire_tag.tag.name}, "
+li
   = t 'attributes.created_at'
   = @cooking_repertoire.created_at.to_s(:datetime_jp)
 li
   = t 'attributes.updated_at'
   = @cooking_repertoire.updated_at.to_s(:datetime_jp)
-= link_to (t '.edit'), edit_cooking_repertoire_path
-br
-= link_to (t '.delete'), @cooking_repertoire, method: :delete, data: { confirm: (t '.delete_confirmation', {name: @cooking_repertoire.name}) }
-br
-= link_to (t '.back_list'), root_path
+div = link_to (t '.edit'), edit_cooking_repertoire_path
+div = link_to (t '.delete'), @cooking_repertoire, method: :delete, data: { confirm: (t '.delete_confirmation', {name: @cooking_repertoire.name}) }
+div = link_to (t '.back_list'), root_path

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -7,6 +7,7 @@ ja:
       cooking_repertoire:
         id: 'ID: '
         name: 'レパートリー名: '
+        tag: 'タグ: '
       tag:
         delete: 消去
   attributes:


### PR DESCRIPTION
closed #19 
# やったこと
1.レパートリー詳細の欄にレパートリー名にひもづくタグを全て取得して表示する

# 詳細画面
<img width="316" alt="スクリーンショット 2020-04-27 8 46 22" src="https://user-images.githubusercontent.com/62975075/80323192-ec40d380-8864-11ea-9979-a8e04fae44d3.png">


# データベース情報
cooking_repertoiresテーブル
<img width="523" alt="スクリーンショット 2020-04-27 8 46 38" src="https://user-images.githubusercontent.com/62975075/80323202-fb278600-8864-11ea-846e-67370355d77d.png">

tagsテーブル
<img width="498" alt="スクリーンショット 2020-04-27 8 47 32" src="https://user-images.githubusercontent.com/62975075/80323211-05498480-8865-11ea-9b76-d2f7394fcb93.png">

中間テーブル
<img width="610" alt="スクリーンショット 2020-04-27 9 08 01" src="https://user-images.githubusercontent.com/62975075/80323497-a38a1a00-8866-11ea-8184-f662fabb4f9f.png">

