### PR TITLE
views/cooking_repertoires/indexの削除

### DIFF
--- a/app/views/cooking_repertoires/index.slim
+++ b/app/views/cooking_repertoires/index.slim
@@ -1,6 +1,0 @@
-= flash.notice
-h1 = t('.title')
-= link_to t('.to_tags'), tags_path
-- @cooking_repertoires.each do |cooking_repertoire|
-  li = link_to cooking_repertoire.name, cooking_repertoire_path(cooking_repertoire.id)
-= link_to t('.new_registration'), new_cooking_repertoire_path


### PR DESCRIPTION
closed #51 
# やったこと
CRUDアプリ作成では必要でしたが研修用アプリには不要なためviews/cooking_repertoires/index.slimのファイル削除する