### PR TITLE
30日の献立を決定する機能の実装

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,6 +1,6 @@
 class MenusController < ApplicationController
   def index
-    @menus = Menu.where('date >= ?', Date.today)
+    @menus = Menu.where('date >= ?', Date.today).order(:date)
   end
 
   def new

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -19,9 +19,9 @@ class MenusController < ApplicationController
 
   def added_message(from_date, to_date)
     if from_date == to_date
-      t('.added_menu', { day: from_date })
+      t('.added_menu', { day: l(from_date) })
     else
-      t('.added_menus', { start_day: from_date, end_day: to_date })
+      t('.added_menus', { start_day: l(from_date), end_day: l(to_date) })
     end
   end
 end

--- a/app/helpers/menus_helper.rb
+++ b/app/helpers/menus_helper.rb
@@ -1,5 +1,5 @@
 module MenusHelper
   def periods
-    { I18n.t('.menus.new.one_day') => 1, I18n.t('.menus.new.seven_days') => 7 }
+    { I18n.t('.menus.new.one_day') => 1, I18n.t('.menus.new.seven_days') => 7, I18n.t('.menus.new.thirty_days') => 30 }
   end
 end

--- a/app/views/menus/index.slim
+++ b/app/views/menus/index.slim
@@ -1,5 +1,6 @@
+= flash.notice
 div = link_to t('.decide_menu'), new_menu_path
 - @menus.each do |menu|
-  div = menu.date
+  div = l(menu.date)
   div = menu.cooking_repertoire.name
 = link_to t('.to_tags'), tags_path

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -17,3 +17,6 @@ ja:
     submit:
       menu:
         create: 献立を決定する
+  time:
+    formats:
+      default: '%Y/%m/%d'

--- a/config/locales/views/menus/ja.yml
+++ b/config/locales/views/menus/ja.yml
@@ -6,3 +6,4 @@ ja:
     new:
       one_day: 1日
       seven_days: 7日
+      thirty_days: 30日


### PR DESCRIPTION
closed #23 
# やったこと
1.プルダウンに30日を追加する
※1ヶ月分とすると月によりばらつきが出るため意図的に30日と明記しています。
2.「献立を決定する」クリックで30日分の献立をランダムで作成する
3.作成後、トップページに遷移する
4.アラート表示する(yyyy/mm/ddからyyyy/mm/ddの献立を作成しました)

# 実行画面
<img width="182" alt="スクリーンショット 2020-05-07 14 10 20" src="https://user-images.githubusercontent.com/62975075/81259272-9513dd80-9072-11ea-859d-ab273287aa5a.png">

___

<img width="452" alt="スクリーンショット 2020-05-07 14 13 13" src="https://user-images.githubusercontent.com/62975075/81259286-9a712800-9072-11ea-9358-39bd938dc335.png">
<img width="403" alt="スクリーンショット 2020-05-07 14 13 31" src="https://user-images.githubusercontent.com/62975075/81259301-9f35dc00-9072-11ea-960a-f230dc922024.png">

