### PR TITLE
レパートリー新規登録(編集)時、タグの個数にバリデーションをかける

### DIFF
--- a/app/controllers/cooking_repertoires_controller.rb
+++ b/app/controllers/cooking_repertoires_controller.rb
@@ -15,7 +15,7 @@ class CookingRepertoiresController < ApplicationController
     @tags = Tag.category
 
     if @cooking_repertoire.save
-      redirect_to :root, notice: t('.added_repertoire', { name: @cooking_repertoire.name })
+      redirect_to tags_path, notice: t('.added_repertoire', { name: @cooking_repertoire.name })
     else
       render :new
     end

--- a/app/models/cooking_repertoire.rb
+++ b/app/models/cooking_repertoire.rb
@@ -1,5 +1,6 @@
 class CookingRepertoire < ApplicationRecord
   validates :name, presence: true, uniqueness: true
+  validate :cooking_repertoire_tags_record
 
   has_many :cooking_repertoire_tags
   has_many :tags, through: :cooking_repertoire_tags
@@ -7,4 +8,14 @@ class CookingRepertoire < ApplicationRecord
   has_many :menus
 
   scope :random_id, -> { offset(rand(CookingRepertoire.count)).first.id }
+
+  private
+
+  def cooking_repertoire_tags_record
+    if cooking_repertoire_tags.empty?
+      errors.add(:base, I18n.t('activerecord.errors.messages.no_select'))
+    elsif cooking_repertoire_tags.size > 3
+      errors.add(:base, I18n.t('activerecord.errors.messages.more_than_3'))
+    end
+  end
 end

--- a/app/models/cooking_repertoire.rb
+++ b/app/models/cooking_repertoire.rb
@@ -1,6 +1,6 @@
 class CookingRepertoire < ApplicationRecord
   validates :name, presence: true, uniqueness: true
-  validate :cooking_repertoire_tags_record
+  validate :tag_number_limit_validation
 
   has_many :cooking_repertoire_tags
   has_many :tags, through: :cooking_repertoire_tags
@@ -11,7 +11,7 @@ class CookingRepertoire < ApplicationRecord
 
   private
 
-  def cooking_repertoire_tags_record
+  def tag_number_limit_validation
     if cooking_repertoire_tags.empty?
       errors.add(:base, I18n.t('activerecord.errors.messages.no_select'))
     elsif cooking_repertoire_tags.size > 3

--- a/app/models/cooking_repertoire.rb
+++ b/app/models/cooking_repertoire.rb
@@ -1,6 +1,6 @@
 class CookingRepertoire < ApplicationRecord
   validates :name, presence: true, uniqueness: true
-  validate :tag_number_limit_validation
+  validate :tag_size_limit
 
   has_many :cooking_repertoire_tags
   has_many :tags, through: :cooking_repertoire_tags
@@ -11,7 +11,7 @@ class CookingRepertoire < ApplicationRecord
 
   private
 
-  def tag_number_limit_validation
+  def tag_size_limit
     if cooking_repertoire_tags.empty?
       errors.add(:base, I18n.t('activerecord.errors.messages.no_select'))
     elsif cooking_repertoire_tags.size > 3

--- a/app/views/cooking_repertoires/_form.slim
+++ b/app/views/cooking_repertoires/_form.slim
@@ -7,3 +7,4 @@
   = form.text_field :name
   div = form.collection_check_boxes :tag_ids, tags, :id, :name
   = form.submit
+= link_to t('.to_tags'), tags_path

--- a/app/views/cooking_repertoires/_form.slim
+++ b/app/views/cooking_repertoires/_form.slim
@@ -3,8 +3,9 @@
     ul
       - cooking_repertoire.errors.full_messages.each do |message|
         li = message
-  = form.label :name
-  = form.text_field :name
-  div = form.collection_check_boxes :tag_ids, tags, :id, :name
+  .required = form.label :name
+  = form.text_field :name, required: true
+  .required = form.collection_check_boxes :tag_ids, tags, :id, :name
+  div 複数選択可、3つまで
   = form.submit
 = link_to t('.to_tags'), tags_path

--- a/app/views/cooking_repertoires/_form.slim
+++ b/app/views/cooking_repertoires/_form.slim
@@ -6,6 +6,6 @@
   .required = form.label :name
   = form.text_field :name, required: true
   .required = form.collection_check_boxes :tag_ids, tags, :id, :name
-  div 複数選択可、3つまで
+  div = t('.supplement_info')
   = form.submit
 = link_to t('.to_tags'), tags_path

--- a/app/views/cooking_repertoires/show.slim
+++ b/app/views/cooking_repertoires/show.slim
@@ -1,22 +1,22 @@
 h1 = t('.title')
 li
-  = CookingRepertoire.human_attribute_name(:id)
+  = CookingRepertoire.human_attribute_name(:id) + t('.break')
   = @cooking_repertoire.id
 li
-  = CookingRepertoire.human_attribute_name(:name)
+  = CookingRepertoire.human_attribute_name(:name) + t('.break')
   = @cooking_repertoire.name
 li
-  = CookingRepertoire.human_attribute_name(:tag)
+  = CookingRepertoire.human_attribute_name(:tag) + t('.break')
   - @cooking_repertoire.cooking_repertoire_tags.each.with_index(1) do |cooking_repertoire_tag, index|
     - if index == @cooking_repertoire.cooking_repertoire_tags.size
       = cooking_repertoire_tag.tag.name
     - else
       = "#{cooking_repertoire_tag.tag.name}, "
 li
-  = CookingRepertoire.human_attribute_name(:created_at)
+  = CookingRepertoire.human_attribute_name(:created_at) + t('.break')
   = @cooking_repertoire.created_at.to_s(:datetime_jp)
 li
-  = CookingRepertoire.human_attribute_name(:updated_at)
+  = CookingRepertoire.human_attribute_name(:updated_at) + t('.break')
   = @cooking_repertoire.updated_at.to_s(:datetime_jp)
 div = link_to t('.edit'), edit_cooking_repertoire_path
 div = link_to t('.delete'), @cooking_repertoire, method: :delete, data: { confirm: t('.delete_confirmation', {name: @cooking_repertoire.name}) }

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -6,9 +6,9 @@ ja:
       menu:
     attributes:
       cooking_repertoire:
-        id: 'ID: '
-        name: 'レパートリー名: '
-        tag: 'タグ: '
+        id: ID
+        name: レパートリー名
+        tag: タグ
       tag:
         delete: 消去
       menu:
@@ -16,6 +16,10 @@ ja:
         period:
           one_day: 1日
           seven_days: 7日
+    errors:
+      messages:
+        no_select: タグを1つ以上指定してください
+        more_than_3: タグは最大で3つまでしか指定できません
   attributes:
-      created_at: '登録日時: '
-      updated_at: '更新日時: '
+      created_at: 登録日時
+      updated_at: 更新日時

--- a/config/locales/views/cooking_repertoires/ja.yml
+++ b/config/locales/views/cooking_repertoires/ja.yml
@@ -17,3 +17,4 @@ ja:
       title: レパートリー名編集
     form:
       to_tags: タグ一覧へ
+      supplement_info: 複数選択可、3つまで

--- a/config/locales/views/cooking_repertoires/ja.yml
+++ b/config/locales/views/cooking_repertoires/ja.yml
@@ -10,6 +10,7 @@ ja:
       title: レパートリーの詳細
       back_list: 一覧へ戻る
       delete_confirmation: レパートリー名「%{name}」を削除します。よろしいですか？
+      break: ': '
       edit: 編集
       delete: 削除
     edit:

--- a/config/locales/views/cooking_repertoires/ja.yml
+++ b/config/locales/views/cooking_repertoires/ja.yml
@@ -14,3 +14,5 @@ ja:
       delete: 削除
     edit:
       title: レパートリー名編集
+    form:
+      to_tags: タグ一覧へ


### PR DESCRIPTION
closed #32 
# やったこと
1.レパートリー名、タグに必須マークをつける　※必須マークをつけることは必須ではない
=>見た目を整える時にcssの擬似要素で必須マークをつける予定なのでクラスだけ付与しました。
2.ビューに補足情報を加える
・複数選択可、3つまで
3.レパートリーの新規登録/編集の際にバリデーション(保存できるタグ1~3個)をかける
4.バリデーションに引っかかったらエラーメッセージを表示する
　・タグを選択せずに保存しようとした時
　・タグを4個以上で保存しようとした時

# 実行画面
<img width="1082" alt="スクリーンショット 2020-05-08 8 57 27" src="https://user-images.githubusercontent.com/62975075/81357241-0fde0680-910e-11ea-8f9c-098df1ed77e3.png">

___
<img width="1050" alt="スクリーンショット 2020-05-08 8 57 13" src="https://user-images.githubusercontent.com/62975075/81357245-12d8f700-910e-11ea-9726-060a2841210c.png">

