### PR TITLE
レパートリーの削除機能を実装する

### DIFF
--- a/app/controllers/cooking_repertoire_tags_controller.rb
+++ b/app/controllers/cooking_repertoire_tags_controller.rb
@@ -1,0 +1,15 @@
+class CookingRepertoireTagsController < ApplicationController
+  def create
+    find_cooking_repertoire_tags
+    cooking_repertoire_tag = CookingRepertoireTag.new(cooking_repertoire_id: @cooking_repertoire.id, tag_id: @tag.id)
+    cooking_repertoire_tag.save
+    redirect_to tags_path, notice: t('.deleted_repertoire', { name: @cooking_repertoire.name })
+  end
+
+  private
+
+  def find_cooking_repertoire_tags
+    @cooking_repertoire = CookingRepertoire.find(params[:format])
+    @tag = Tag.find_by(name: Tag.human_attribute_name(:delete))
+  end
+end

--- a/app/controllers/cooking_repertoire_tags_controller.rb
+++ b/app/controllers/cooking_repertoire_tags_controller.rb
@@ -1,14 +1,17 @@
 class CookingRepertoireTagsController < ApplicationController
   def create
-    find_cooking_repertoire_tags
+    cooking_repertoire_and_tag
     cooking_repertoire_tag = CookingRepertoireTag.new(cooking_repertoire_id: @cooking_repertoire.id, tag_id: @tag.id)
-    cooking_repertoire_tag.save
-    redirect_to tags_path, notice: t('.deleted_repertoire', { name: @cooking_repertoire.name })
+    if cooking_repertoire_tag.save
+      redirect_to tags_path, notice: t('.deleted_repertoire', { name: @cooking_repertoire.name })
+    else
+      redirect_to cooking_repertoire_path(@cooking_repertoire), notice: t('.failed_delete')
+    end
   end
 
   private
 
-  def find_cooking_repertoire_tags
+  def cooking_repertoire_and_tag
     @cooking_repertoire = CookingRepertoire.find(params[:format])
     @tag = Tag.find_by(name: Tag.human_attribute_name(:delete))
   end

--- a/app/controllers/cooking_repertoires_controller.rb
+++ b/app/controllers/cooking_repertoires_controller.rb
@@ -29,7 +29,7 @@ class CookingRepertoiresController < ApplicationController
     @tags = Tag.category
 
     if @cooking_repertoire.update(cooking_repertoire_params)
-      redirect_to :root, notice: t('.edited_repertoire', { name: @cooking_repertoire.name })
+      redirect_to tags_path, notice: t('.edited_repertoire', { name: @cooking_repertoire.name })
     else
       render :edit
     end

--- a/app/views/cooking_repertoires/show.slim
+++ b/app/views/cooking_repertoires/show.slim
@@ -1,3 +1,4 @@
+= flash.notice
 h1 = t('.title')
 li
   = CookingRepertoire.human_attribute_name(:id) + t('.break')

--- a/app/views/cooking_repertoires/show.slim
+++ b/app/views/cooking_repertoires/show.slim
@@ -19,5 +19,5 @@ li
   = CookingRepertoire.human_attribute_name(:updated_at) + t('.break')
   = @cooking_repertoire.updated_at.to_s(:datetime_jp)
 div = link_to t('.edit'), edit_cooking_repertoire_path
-div = link_to t('.delete'), @cooking_repertoire, method: :delete, data: { confirm: t('.delete_confirmation', {name: @cooking_repertoire.name}) }
+div = link_to t('.delete'), cooking_repertoire_tags_path(@cooking_repertoire), method: :post, data: { confirm: t('.delete_confirmation', {name: @cooking_repertoire.name}) }
 div = link_to t('.back_list'), tags_path

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,6 +13,9 @@ ja:
     create:
       added_menu: '%{day}の献立を作成しました'
       added_menus: '%{start_day}から%{end_day}までの献立を作成しました'
+  cooking_repertoire_tags:
+    create:
+      deleted_repertoire: レパートリー名「%{name}」を削除しました。
   helpers:
     submit:
       menu:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,6 +16,7 @@ ja:
   cooking_repertoire_tags:
     create:
       deleted_repertoire: レパートリー名「%{name}」を削除しました。
+      failed_delete: 削除に失敗しました
   helpers:
     submit:
       menu:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :cooking_repertoires, only: [:new, :create, :show, :edit, :update, :destroy]
+  resources :cooking_repertoire_tags, only: [:create]
   resources :tags, only: [:index]
   resources :menus, only: [:index, :new, :create]
   root to: 'menus#index'


### PR DESCRIPTION
closed #34 
refs #35 
# やったこと
※レパートリー詳細に削除ボタンは実装済み #6 
- ルーティングを実装する (cooking_repertoire_tags#create)
- 削除処理を実装する(controller)
  - 対象のレパートリーに削除タグを追加する (model)
  - レパートリー一覧に遷移する&フラッシュメッセージを表示する
- すでに3つタグを持つデータでも保存できるようにする(model)
  - タグの個数制限（1〜3）を Tag model に定義済み

# 実行画面
<img width="349" alt="スクリーンショット 2020-05-08 14 13 07" src="https://user-images.githubusercontent.com/62975075/81373649-2b5e0700-9138-11ea-97a2-d309f8aab4ef.png">

___
<img width="355" alt="スクリーンショット 2020-05-08 14 13 16" src="https://user-images.githubusercontent.com/62975075/81373655-3022bb00-9138-11ea-84bc-2d339b39de2a.png">

___
<img width="363" alt="スクリーンショット 2020-05-08 14 13 25" src="https://user-images.githubusercontent.com/62975075/81373660-331dab80-9138-11ea-9bb0-7908df847014.png">
