### PR TITLE
消去タグのレパートリーを非表示にする

### DIFF
--- a/app/views/tags/index.slim
+++ b/app/views/tags/index.slim
@@ -3,8 +3,9 @@ h1 = t('.title')
 div = link_to t('.new_registration'), new_cooking_repertoire_path
 - @tags.each do |tag|
   h2 = tag.name
-  - if tag.cooking_repertoire_tags.exists?
-    - tag.cooking_repertoire_tags.each do |cooking_repertoire_tag|
-      li = link_to cooking_repertoire_tag.cooking_repertoire.name, cooking_repertoire_path(cooking_repertoire_tag.cooking_repertoire.id)
+  - if tag.cooking_repertoires.present?
+    - tag.cooking_repertoires.each do |cooking_repertoire|
+      - unless cooking_repertoire.tags.exists?(name: t('activerecord.attributes.tag.delete'))
+        li = link_to cooking_repertoire.name, cooking_repertoire_path(cooking_repertoire.id)
   - else
     = t('.no_repertoire_name')


### PR DESCRIPTION
closed #35 
# やったこと
※削除機能は実装済み #34

-レパートリー一覧のページにアクセスした時に消去タグがついているレパートリー名以外を取得して表示する (controller, view)

# 実行結果
<img width="463" alt="スクリーンショット 2020-05-11 10 04 07" src="https://user-images.githubusercontent.com/62975075/81515458-26cf6380-936f-11ea-8f31-e9444f83be4a.png">

____

**消去タグがついているレパートリーが表示されていないかの確認**
とんかつは和食のタグがついていますが消去タグもついているので表示されません
![スクリーンショット 2020-05-11 10 11 08](https://user-images.githubusercontent.com/62975075/81515596-cee52c80-936f-11ea-986c-0c27d407d288.png)

