### PR TITLE
tagsテーブルのnameが消去のレコードを削除に変更

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,7 +8,7 @@ ja:
       deleted_repertoire: レパートリー名「%{name}」を削除しました。
     new:
     edit:
-      delete: 消去
+      delete: 削除
   menus:
     create:
       added_menu: '%{day}の献立を作成しました'

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -10,7 +10,7 @@ ja:
         name: レパートリー名
         tag: タグ
       tag:
-        delete: 消去
+        delete: 削除
       menu:
         date: 献立
         period:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,4 +2,4 @@ tags = Tag.create([{name: '和食'}, {name: '洋食'}, {name: '中華'}, {name: 
                    {name: '豚肉'}, {name: '牛肉'}, {name: '魚介'}, {name: '卵'},
                    {name: '大豆'}, {name: 'ご飯もの'}, {name: 'パスタ'}, {name: '甘い'},
                    {name: '辛い'}, {name: '苦い'}, {name: '酸っぱい'}, {name: '塩辛い'},
-                   {name: '春'}, {name: '夏'}, {name: '秋'}, {name: '冬'}, {name: '消去'}])
+                   {name: '春'}, {name: '夏'}, {name: '秋'}, {name: '冬'}, {name: '削除'}])


### PR DESCRIPTION
closed #56 
# やったこと
- 消去なのか削除なのかややこしいので削除に統一する(db)
  - seed.rbの{name: '消去'}を{name: '削除'}に変更
  - ja.ymlファイルの消去を削除に変更する
- dbを更新する(db)
  - ~rails db:migrate:reset と rails db:seedでdbを更新する(レパートリーや献立は削除される)~
  - sequelproで直接変更しました

# DB情報
<img width="484" alt="スクリーンショット 2020-05-11 15 33 51" src="https://user-images.githubusercontent.com/62975075/81530967-dc64db80-939c-11ea-9403-244ad3bd5345.png">
