### PR TITLE
削除タグがついたレパートリーを除いて献立を作成する機能

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,9 +10,9 @@ Style/FrozenStringLiteralComment:
 Style/SymbolArray:
   EnforcedStyle: brackets
 
-# 1行あたりの文字数を120文字にする
+# 1行あたりの文字数を150文字にする
 Layout/LineLength:
-  Max: 120
+  Max: 150
 
 # rubocop起動時に警告が出たのでtrue or falseの選択
 Layout/SpaceAroundMethodCallOperator:

--- a/app/models/cooking_repertoire.rb
+++ b/app/models/cooking_repertoire.rb
@@ -7,7 +7,9 @@ class CookingRepertoire < ApplicationRecord
   accepts_nested_attributes_for :cooking_repertoire_tags
   has_many :menus
 
-  scope :random_id, -> { offset(rand(CookingRepertoire.count)).first.id }
+  scope :deleted, -> { joins(:tags).where(tags: { name: Tag.human_attribute_name(:delete) }) }
+  scope :valid, -> { where.not(id: CookingRepertoire.deleted) }
+  scope :random_id, -> { CookingRepertoire.valid.sample.id }
 
   private
 

--- a/app/models/cooking_repertoire.rb
+++ b/app/models/cooking_repertoire.rb
@@ -9,7 +9,7 @@ class CookingRepertoire < ApplicationRecord
 
   scope :deleted, -> { joins(:tags).where(tags: { name: Tag.human_attribute_name(:delete) }) }
   scope :valid, -> { where.not(id: CookingRepertoire.deleted) }
-  scope :random_id, -> { CookingRepertoire.valid.sample.id }
+  scope :random, -> { CookingRepertoire.valid.sample }
 
   private
 

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -6,7 +6,7 @@ class Menu < ApplicationRecord
   def self.make(from, to)
     (from..to).each do |day|
       menu = Menu.find_or_initialize_by(date: day)
-      menu.update_attributes!({ cooking_repertoire_id: CookingRepertoire.random_id })
+      menu.update_attributes!({ cooking_repertoire_id: CookingRepertoire.random.id })
     end
   end
 end


### PR DESCRIPTION
closed #58 
# やったこと
- rubocopの規制緩和(1行あたりの文字数を150字に変更)

※献立作成機能は実装済み #23
- 献立作成時に削除したレパートリーは除く実装(model)
  - 削除タグがついているレパートリーを取得する(model)
  - 取得したレパートリーを除くレパートリー (= 削除タグがついていないレパートリー)を取得する(model)
- 取得したレパートリーの中からランダムで一つ取得し献立を作成する。※実装済み

# 実行結果
**たこ焼き、カツ丼、とんかつ、塩焼きそばが削除済みのレパートリーです**
![スクリーンショット 2020-05-11 17 25 30](https://user-images.githubusercontent.com/62975075/81540324-71230580-93ac-11ea-9dc6-dc727822604d.png)

<img width="509" alt="スクリーンショット 2020-05-11 17 19 39" src="https://user-images.githubusercontent.com/62975075/81540280-5cdf0880-93ac-11ea-9bdb-2ab7e4b4847c.png">
<img width="321" alt="スクリーンショット 2020-05-11 17 20 00" src="https://user-images.githubusercontent.com/62975075/81540286-5e103580-93ac-11ea-8b5e-c660783bdc55.png">

