### PR TITLE
前後被らない日数の設定できる機能の実装

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -9,7 +9,7 @@ class MenusController < ApplicationController
   end
 
   def create
-    if Menu.make(@from_date, @to_date, @not_duplicate)
+    if Menu.make(@from_date, @to_date, @not_duplicate_day)
       redirect_to menus_path, notice: added_message(@from_date, @to_date)
     else
       redirect_to new_menu_path, notice: t('.creation_failed')
@@ -22,7 +22,7 @@ class MenusController < ApplicationController
     period = params[:menu][:period].to_i
     @from_date = Date.parse(params[:menu][:date])
     @to_date = @from_date + period - 1
-    @not_duplicate = params[:menu][:not_duplicate].to_i
+    @not_duplicate_day = params[:menu][:not_duplicate_day].to_i
   end
 
   def added_message(from_date, to_date)

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -12,7 +12,7 @@ class MenusController < ApplicationController
     if Menu.make(@from_date, @to_date, @not_duplicate)
       redirect_to menus_path, notice: added_message(@from_date, @to_date)
     else
-      redirect_to new_menu_path, notice: t('.fail_create')
+      redirect_to new_menu_path, notice: t('.creation_failed')
     end
   end
 

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -8,14 +8,22 @@ class MenusController < ApplicationController
   end
 
   def create
-    period = params[:menu][:period].to_i
-    from_date = Date.parse(params[:menu][:date])
-    to_date = from_date + period - 1
-    Menu.make(from_date, to_date)
-    redirect_to menus_path, notice: added_message(from_date, to_date)
+    menu_params
+    if Menu.make(@from_date, @to_date, @not_duplicate)
+      redirect_to menus_path, notice: added_message(@from_date, @to_date)
+    else
+      redirect_to new_menu_path, notice: t('.fail_create')
+    end
   end
 
   private
+
+  def menu_params
+    period = params[:menu][:period].to_i
+    @from_date = Date.parse(params[:menu][:date])
+    @to_date = @from_date + period - 1
+    @not_duplicate = params[:menu][:not_duplicate].to_i
+  end
 
   def added_message(from_date, to_date)
     if from_date == to_date

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,4 +1,5 @@
 class MenusController < ApplicationController
+  before_action :initialize_menu_params, only: [:create]
   def index
     @menus = Menu.where('date >= ?', Date.today).order(:date)
   end
@@ -8,7 +9,6 @@ class MenusController < ApplicationController
   end
 
   def create
-    menu_params
     if Menu.make(@from_date, @to_date, @not_duplicate)
       redirect_to menus_path, notice: added_message(@from_date, @to_date)
     else
@@ -18,7 +18,7 @@ class MenusController < ApplicationController
 
   private
 
-  def menu_params
+  def initialize_menu_params
     period = params[:menu][:period].to_i
     @from_date = Date.parse(params[:menu][:date])
     @to_date = @from_date + period - 1

--- a/app/helpers/menus_helper.rb
+++ b/app/helpers/menus_helper.rb
@@ -12,7 +12,7 @@ module MenusHelper
       cooking_repertoie = CookingRepertoire.valid.where.not(id: exclude_repertoire)
       break if cooking_repertoie.empty?
 
-      @not_duplicate_days[I18n.t('.menus.new.day', i: i)] = i
+      @not_duplicate_days[I18n.t('.menus.new.day', one_day: i)] = i
     end
     @not_duplicate_days
   end

--- a/app/helpers/menus_helper.rb
+++ b/app/helpers/menus_helper.rb
@@ -9,8 +9,8 @@ module MenusHelper
     (1..7).each do |i|
       tags += before_tags(i)
       exclude_repertoire = CookingRepertoire.joins(:tags).where(tags: { id: tags })
-      cooking_repertoie = CookingRepertoire.valid.where.not(id: exclude_repertoire)
-      break if cooking_repertoie.empty?
+      cooking_repertoire = CookingRepertoire.valid.where.not(id: exclude_repertoire)
+      break if cooking_repertoire.empty?
 
       @not_duplicate_days[I18n.t('.menus.new.day', one_day: i)] = i
     end
@@ -20,7 +20,7 @@ module MenusHelper
   def before_tags(num)
     before_day = Date.today - num
     before_menu = Menu.find_by(date: before_day)
-    cook_id = before_menu[:cooking_repertoire_id]
-    CookingRepertoire.find(cook_id).tags
+    cooking_repertoire_id = before_menu[:cooking_repertoire_id]
+    CookingRepertoire.find(cooking_repertoire_id).tags
   end
 end

--- a/app/helpers/menus_helper.rb
+++ b/app/helpers/menus_helper.rb
@@ -2,4 +2,25 @@ module MenusHelper
   def periods
     { I18n.t('.menus.new.one_day') => 1, I18n.t('.menus.new.seven_days') => 7, I18n.t('.menus.new.thirty_days') => 30 }
   end
+
+  def not_duplicate_days
+    @not_duplicate_days = {}
+    tags = []
+    (1..7).each do |i|
+      tags += before_tags(i)
+      exclude_repertoire = CookingRepertoire.joins(:tags).where(tags: { id: tags })
+      cooking_repertoie = CookingRepertoire.valid.where.not(id: exclude_repertoire)
+      break if cooking_repertoie.empty?
+
+      @not_duplicate_days[I18n.t('.menus.new.day', i: i)] = i
+    end
+    @not_duplicate_days
+  end
+
+  def before_tags(num)
+    before_day = Date.today - num
+    before_menu = Menu.find_by(date: before_day)
+    cook_id = before_menu[:cooking_repertoire_id]
+    CookingRepertoire.find(cook_id).tags
+  end
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -3,9 +3,9 @@ class Menu < ApplicationRecord
 
   belongs_to :cooking_repertoire
 
-  def self.make(from, to, not_duplicate)
+  def self.make(from, to, not_duplicate_day)
     ActiveRecord::Base.transaction do
-      (from..to).each { |day| one_day(not_duplicate, day) }
+      (from..to).each { |day| one_day(not_duplicate_day, day) }
     end
   rescue StandardError => e
     puts e.message
@@ -14,17 +14,17 @@ class Menu < ApplicationRecord
   class << self
     private
 
-    def one_day(not_duplicate, day)
-      tags = exclude_tags(not_duplicate, day)
+    def one_day(not_duplicate_day, day)
+      tags = exclude_tags(not_duplicate_day, day)
       exclude_repertoire = CookingRepertoire.joins(:tags).where(tags: { id: tags })
       cooking_repertoire_id = CookingRepertoire.valid.where.not(id: exclude_repertoire).sample.id
       menu = Menu.find_or_initialize_by(date: day)
       menu.update_attributes!({ cooking_repertoire_id: cooking_repertoire_id })
     end
 
-    def exclude_tags(not_duplicate, day)
+    def exclude_tags(not_duplicate_day, day)
       tags = []
-      (1..not_duplicate).each do |i|
+      (1..not_duplicate_day).each do |i|
         before_day = day - i
         before_menu = Menu.find_by(date: before_day)
         cook_id = before_menu[:cooking_repertoire_id]

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -5,7 +5,7 @@ class Menu < ApplicationRecord
 
   def self.make(from, to, not_duplicate_day)
     ActiveRecord::Base.transaction do
-      (from..to).each { |day| one_day(not_duplicate_day, day) }
+      (from..to).each { |day| make_for_one_day(not_duplicate_day, day) }
     end
   rescue StandardError => e
     puts e.message
@@ -14,7 +14,7 @@ class Menu < ApplicationRecord
   class << self
     private
 
-    def one_day(not_duplicate_day, day)
+    def make_for_one_day(not_duplicate_day, day)
       tags = exclude_tags(not_duplicate_day, day)
       exclude_repertoire = CookingRepertoire.joins(:tags).where(tags: { id: tags })
       cooking_repertoire_id = CookingRepertoire.valid.where.not(id: exclude_repertoire).sample.id

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -3,10 +3,31 @@ class Menu < ApplicationRecord
 
   belongs_to :cooking_repertoire
 
-  def self.make(from, to)
-    (from..to).each do |day|
-      menu = Menu.find_or_initialize_by(date: day)
-      menu.update_attributes!({ cooking_repertoire_id: CookingRepertoire.random.id })
+  def self.make(from, to, not_duplicate)
+    ActiveRecord::Base.transaction do
+      (from..to).each { |day| one_day(not_duplicate, day) }
     end
+  rescue StandardError => e
+    puts e.message
+  end
+
+  def self.one_day(not_duplicate, day)
+    tags = exclude_tags(not_duplicate, day)
+    exclude_repertoire = CookingRepertoire.joins(:tags).where(tags: { id: tags })
+    cooking_repertoire_id = CookingRepertoire.valid.where.not(id: exclude_repertoire).sample.id
+    menu = Menu.find_or_initialize_by(date: day)
+    menu.update_attributes!({ cooking_repertoire_id: cooking_repertoire_id })
+  end
+
+  def self.exclude_tags(not_duplicate, day)
+    tags = []
+    (1..not_duplicate).each do |i|
+      before_day = day - i
+      before_menu = Menu.find_by(date: before_day)
+      cook_id = before_menu[:cooking_repertoire_id]
+      tag = CookingRepertoire.find(cook_id).tags
+      tags += tag
+    end
+    tags
   end
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -11,23 +11,27 @@ class Menu < ApplicationRecord
     puts e.message
   end
 
-  def self.one_day(not_duplicate, day)
-    tags = exclude_tags(not_duplicate, day)
-    exclude_repertoire = CookingRepertoire.joins(:tags).where(tags: { id: tags })
-    cooking_repertoire_id = CookingRepertoire.valid.where.not(id: exclude_repertoire).sample.id
-    menu = Menu.find_or_initialize_by(date: day)
-    menu.update_attributes!({ cooking_repertoire_id: cooking_repertoire_id })
-  end
+  class << self
+    private
 
-  def self.exclude_tags(not_duplicate, day)
-    tags = []
-    (1..not_duplicate).each do |i|
-      before_day = day - i
-      before_menu = Menu.find_by(date: before_day)
-      cook_id = before_menu[:cooking_repertoire_id]
-      tag = CookingRepertoire.find(cook_id).tags
-      tags += tag
+    def one_day(not_duplicate, day)
+      tags = exclude_tags(not_duplicate, day)
+      exclude_repertoire = CookingRepertoire.joins(:tags).where(tags: { id: tags })
+      cooking_repertoire_id = CookingRepertoire.valid.where.not(id: exclude_repertoire).sample.id
+      menu = Menu.find_or_initialize_by(date: day)
+      menu.update_attributes!({ cooking_repertoire_id: cooking_repertoire_id })
     end
-    tags
+
+    def exclude_tags(not_duplicate, day)
+      tags = []
+      (1..not_duplicate).each do |i|
+        before_day = day - i
+        before_menu = Menu.find_by(date: before_day)
+        cook_id = before_menu[:cooking_repertoire_id]
+        tag = CookingRepertoire.find(cook_id).tags
+        tags += tag
+      end
+      tags
+    end
   end
 end

--- a/app/views/menus/index.slim
+++ b/app/views/menus/index.slim
@@ -2,5 +2,10 @@
 div = link_to t('.decide_menu'), new_menu_path
 - @menus.each do |menu|
   div = l(menu.date)
-  div = menu.cooking_repertoire.name
-= link_to t('.to_tags'), tags_path
+  h3 = menu.cooking_repertoire.name
+  - menu.cooking_repertoire.tags.each.with_index(1) do |tag, index|
+    - if index == menu.cooking_repertoire.tags.size
+      = tag.name
+    - else
+      = "#{tag.name}, "
+div = link_to t('.to_tags'), tags_path

--- a/app/views/menus/new.slim
+++ b/app/views/menus/new.slim
@@ -1,3 +1,4 @@
+= flash.notice
 = form_with model: @menu, local: true do |form|
   = form.date_field :date, value: Date.today
   div = form.select :period, options_for_select(periods)

--- a/app/views/menus/new.slim
+++ b/app/views/menus/new.slim
@@ -2,6 +2,6 @@
 = form_with model: @menu, local: true do |form|
   = form.date_field :date, value: Date.today
   div = form.select :period, options_for_select(periods)
-  div = form.label :not_duplicate
-  div = form.select :not_duplicate,  options_for_select(not_duplicate_days)
+  div = form.label :not_duplicate_day
+  div = form.select :not_duplicate_day,  options_for_select(not_duplicate_days)
   div = form.submit

--- a/app/views/menus/new.slim
+++ b/app/views/menus/new.slim
@@ -1,4 +1,6 @@
 = form_with model: @menu, local: true do |form|
   = form.date_field :date, value: Date.today
   div = form.select :period, options_for_select(periods)
+  div = form.label :not_duplicate
+  div = form.select :not_duplicate,  options_for_select(not_duplicate_days)
   div = form.submit

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,6 +13,7 @@ ja:
     create:
       added_menu: '%{day}の献立を作成しました'
       added_menus: '%{start_day}から%{end_day}までの献立を作成しました'
+      fail_create: 献立の作成に失敗しました。重複しない日数を減らして再度作成してください
   cooking_repertoire_tags:
     create:
       deleted_repertoire: レパートリー名「%{name}」を削除しました。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,7 +13,7 @@ ja:
     create:
       added_menu: '%{day}の献立を作成しました'
       added_menus: '%{start_day}から%{end_day}までの献立を作成しました'
-      fail_create: 献立の作成に失敗しました。重複しない日数を減らして再度作成してください
+      creation_failed: 献立の作成に失敗しました。重複しない日数を減らして再度作成してください
   cooking_repertoire_tags:
     create:
       deleted_repertoire: レパートリー名「%{name}」を削除しました。

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -16,6 +16,7 @@ ja:
         period:
           one_day: 1日
           seven_days: 7日
+        not_duplicate: 重複しない日数
     errors:
       messages:
         no_select: タグを1つ以上指定してください

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -16,7 +16,7 @@ ja:
         period:
           one_day: 1日
           seven_days: 7日
-        not_duplicate: 重複しない日数
+        not_duplicate_day: 重複しない日数
     errors:
       messages:
         no_select: タグを1つ以上指定してください

--- a/config/locales/views/menus/ja.yml
+++ b/config/locales/views/menus/ja.yml
@@ -7,4 +7,4 @@ ja:
       one_day: 1日
       seven_days: 7日
       thirty_days: 30日
-      day: '%{i}日'
+      day: '%{one_day}日'

--- a/config/locales/views/menus/ja.yml
+++ b/config/locales/views/menus/ja.yml
@@ -7,3 +7,4 @@ ja:
       one_day: 1日
       seven_days: 7日
       thirty_days: 30日
+      day: '%{i}日'


### PR DESCRIPTION
closed #24 
# やったこと
- 献立一覧にレパートリーにひもづくタグを表示する
- 前後被らない日数(1~7日)を選択できる機能の実装(view, model)
  - 献立作成時に前後被らない日数を選択できる画面を作成する(view)
  - 選択した日数分被らないように献立を作成する(model)
- 献立の作成失敗時の処理を追加する(例えば7日と選択したが6日間で全てのタグが使用された場合)
下記の2パターンのどちらかを実装する。理想は後者
  - トランザクションの処理を実装する(model)
作成に失敗した際、日数を減らして作成してくださいの旨を伝えたエラーメッセージを表示する
  - あらかじめ作成できる(前後被らない)日数のみを表示する(model)

# 実行結果
**献立新規作成画面(menus/new)**
<img width="219" alt="スクリーンショット 2020-05-13 14 10 05" src="https://user-images.githubusercontent.com/62975075/81773551-7ce50800-9523-11ea-992b-119914becda3.png">

既存の献立で使用していないレパートリー(例:　{name: そうめん, tag: 夏})が存在する場合
※重複しない日数7日を選択肢30日作成しようとした場合作成に失敗することがあります

____

<img width="177" alt="スクリーンショット 2020-05-13 14 14 07" src="https://user-images.githubusercontent.com/62975075/81773770-0b598980-9524-11ea-9669-a73d6af247af.png">

**献立作成結果(重複しない日数3日で作成)**

___

<img width="215" alt="スクリーンショット 2020-05-13 14 06 16" src="https://user-images.githubusercontent.com/62975075/81773351-119b3600-9523-11ea-83a2-b1b147a133a7.png">

<img width="212" alt="スクリーンショット 2020-05-13 14 06 46" src="https://user-images.githubusercontent.com/62975075/81773370-17911700-9523-11ea-8dc0-4ca27b34020e.png">

<img width="290" alt="スクリーンショット 2020-05-13 14 08 17" src="https://user-images.githubusercontent.com/62975075/81773499-50c98700-9523-11ea-8f8c-66596cb4c923.png">

<img width="296" alt="スクリーンショット 2020-05-13 14 08 29" src="https://user-images.githubusercontent.com/62975075/81773512-5921c200-9523-11ea-87fb-f3ffcc09fab5.png">

<img width="295" alt="スクリーンショット 2020-05-13 14 08 40" src="https://user-images.githubusercontent.com/62975075/81773517-5c1cb280-9523-11ea-82c7-b91af3045617.png">

___
**献立作成失敗時**

<img width="579" alt="スクリーンショット 2020-05-13 13 41 24" src="https://user-images.githubusercontent.com/62975075/81774340-48724b80-9525-11ea-8b7b-0ca694290365.png">



