### PR TITLE
献立の候補となるタグを保存するテーブルを作成する

### DIFF
--- a/app/models/menu_candidate_tag.rb
+++ b/app/models/menu_candidate_tag.rb
@@ -1,0 +1,2 @@
+class MenuCandidateTag < ApplicationRecord
+end

--- a/db/migrate/20200514044713_create_menu_candidate_tags.rb
+++ b/db/migrate/20200514044713_create_menu_candidate_tags.rb
@@ -1,0 +1,9 @@
+class CreateMenuCandidateTags < ActiveRecord::Migration[6.0]
+  def change
+    create_table :menu_candidate_tags do |t|
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_24_063657) do
+ActiveRecord::Schema.define(version: 2020_05_14_044713) do
 
   create_table "cooking_repertoire_tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "cooking_repertoire_id", null: false
@@ -26,6 +26,13 @@ ActiveRecord::Schema.define(version: 2020_04_24_063657) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_cooking_repertoires_on_name", unique: true
+  end
+
+  create_table "menu_candidate_tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["tag_id"], name: "index_menu_candidate_tags_on_tag_id"
   end
 
   create_table "menus", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -46,5 +53,6 @@ ActiveRecord::Schema.define(version: 2020_04_24_063657) do
 
   add_foreign_key "cooking_repertoire_tags", "cooking_repertoires"
   add_foreign_key "cooking_repertoire_tags", "tags"
+  add_foreign_key "menu_candidate_tags", "tags"
   add_foreign_key "menus", "cooking_repertoires"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,5 @@
-tags = Tag.create([{name: '和食'}, {name: '洋食'}, {name: '中華'}, {name: '鶏肉'},
-                   {name: '豚肉'}, {name: '牛肉'}, {name: '魚介'}, {name: '卵'},
-                   {name: '大豆'}, {name: 'ご飯もの'}, {name: 'パスタ'}, {name: '甘い'},
-                   {name: '辛い'}, {name: '苦い'}, {name: '酸っぱい'}, {name: '塩辛い'},
-                   {name: '春'}, {name: '夏'}, {name: '秋'}, {name: '冬'}, {name: '削除'}])
+Tag.create([{ name: '和食' }, { name: '洋食' }, { name: '中華' }, { name: '鶏肉' },
+            { name: '豚肉' }, { name: '牛肉' }, { name: '魚介' }, { name: '卵' },
+            { name: '大豆' }, { name: 'ご飯もの' }, { name: 'パスタ' }, { name: '甘い' },
+            { name: '辛い' }, { name: '苦い' }, { name: '酸っぱい' }, { name: '塩辛い' },
+            { name: '春' }, { name: '夏' }, { name: '秋' }, { name: '冬' }, { name: '削除' }])


### PR DESCRIPTION
closed #25 
# やったこと
- rubocopの規約に引っかかった箇所の修正
- 献立作成時に献立の候補になったタグを保存するテーブルを作成する
  - モデルを作成する(model名: MenuCandidateTag)
  - マイグレーションファイルにカラム情報を記述する

実行結果
DB情報
![スクリーンショット 2020-05-14 14 04 02](https://user-images.githubusercontent.com/62975075/81894884-d0228d80-95eb-11ea-9261-9196ec676088.png)

