### PR TITLE
7日前までの献立が存在しない場合に生じるエラーを解決する

### DIFF
--- a/app/helpers/menus_helper.rb
+++ b/app/helpers/menus_helper.rb
@@ -4,7 +4,7 @@ module MenusHelper
   end
 
   def not_duplicate_days
-    @not_duplicate_days = {}
+    not_duplicate_days = {}
     tags = []
     (1..7).each do |i|
       tags += before_tags(i)
@@ -12,15 +12,19 @@ module MenusHelper
       cooking_repertoire = CookingRepertoire.valid.where.not(id: exclude_repertoire)
       break if cooking_repertoire.empty?
 
-      @not_duplicate_days[I18n.t('.menus.new.day', one_day: i)] = i
+      not_duplicate_days[I18n.t('.menus.new.day', one_day: i)] = i
     end
-    @not_duplicate_days
+    not_duplicate_days
   end
 
   def before_tags(num)
     before_day = Date.today - num
     before_menu = Menu.find_by(date: before_day)
-    cooking_repertoire_id = before_menu[:cooking_repertoire_id]
-    CookingRepertoire.find(cooking_repertoire_id).tags
+    if before_menu.nil?
+      []
+    else
+      cooking_repertoire_id = before_menu.cooking_repertoire_id
+      CookingRepertoire.find(cooking_repertoire_id).tags
+    end
   end
 end

--- a/app/helpers/menus_helper.rb
+++ b/app/helpers/menus_helper.rb
@@ -20,11 +20,9 @@ module MenusHelper
   def before_tags(num)
     before_day = Date.today - num
     before_menu = Menu.find_by(date: before_day)
-    if before_menu.nil?
-      []
-    else
-      cooking_repertoire_id = before_menu.cooking_repertoire_id
-      CookingRepertoire.find(cooking_repertoire_id).tags
-    end
+    return [] if before_menu.nil?
+
+    cooking_repertoire_id = before_menu.cooking_repertoire_id
+    CookingRepertoire.find(cooking_repertoire_id).tags
   end
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -27,6 +27,8 @@ class Menu < ApplicationRecord
       (1..not_duplicate_day).each do |i|
         before_day = day - i
         before_menu = Menu.find_by(date: before_day)
+        next if before_menu.nil?
+
         cooking_repertoire_id = before_menu.cooking_repertoire_id
         tag = CookingRepertoire.find(cooking_repertoire_id).tags
         tags += tag


### PR DESCRIPTION
closed #63 
## やったこと
- 献立新規作成画面にアクセスするときに7日前までの献立が存在しないとエラーが表示される(下記エラー)問題を解決する(view)
- 献立が存在する場合、しない場合で条件分岐をする
「献立を作成する」ボタンを押したときに「被らない日数」で選択した日数(例: 3日)分の献立が存在しない(例: 5月15日に作成するときに5月14日の献立が存在しない)と献立が作成できない問題を解決する(model)
  - 献立が存在する場合、しない場合で条件分岐をする

## 実行結果
- 5月18日より前の献立が存在しない状態
<img width="239" alt="スクリーンショット 2020-05-18 11 31 49" src="https://user-images.githubusercontent.com/62975075/82170167-a1175f00-98fe-11ea-832f-63ec97fe3783.png">

- 献立新規作成画面にアクセス
<img width="1056" alt="スクリーンショット 2020-05-18 11 28 17" src="https://user-images.githubusercontent.com/62975075/82170285-f5224380-98fe-11ea-8edb-82c2866b7570.png">

- 献立を作成
<img width="419" alt="スクリーンショット 2020-05-18 11 58 25" src="https://user-images.githubusercontent.com/62975075/82170483-8691b580-98ff-11ea-9a63-13c34fcc2083.png">



