### PR TITLE
グローバルメニューを作成し全画面に配置

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -17,4 +17,5 @@ require("channels")
 // const imagePath = (name) => images(name, true)
 
 import 'bootstrap';
+import '@fortawesome/fontawesome-free/js/all';
 import '../stylesheets/application';

--- a/app/javascript/stylesheets/_footer.scss
+++ b/app/javascript/stylesheets/_footer.scss
@@ -1,0 +1,6 @@
+.nav-link {
+  font-size: 0.5rem;
+  a{
+    display: block;
+  }
+}

--- a/app/javascript/stylesheets/_footer.scss
+++ b/app/javascript/stylesheets/_footer.scss
@@ -1,6 +1,18 @@
-.nav-link {
-  font-size: 0.5rem;
-  a{
-    display: block;
+body {
+  padding-bottom: 70px;
+}
+
+.nav-item{
+  position: relative;
+  padding: 0.5rem;
+  .nav-link {
+    font-size: 0.5rem;
+    border: none;
+  }
+}
+
+.nav-item.active {
+  a {
+    color: #ffc107 !important;
   }
 }

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,1 +1,2 @@
 @import '~bootstrap/scss/bootstrap';
+@import '~@fortawesome/fontawesome-free/scss/fontawesome';

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,7 +1,3 @@
 @import '~bootstrap/scss/bootstrap';
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';
 @import './footer.scss';
-
-body {
-  padding-bottom: 70px;
-}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,2 +1,7 @@
 @import '~bootstrap/scss/bootstrap';
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';
+@import './footer.scss';
+
+body {
+  padding-bottom: 70px;
+}

--- a/app/views/cooking_repertoires/_form.slim
+++ b/app/views/cooking_repertoires/_form.slim
@@ -8,4 +8,3 @@
   .required = form.collection_check_boxes :tag_ids, tags, :id, :name
   div = t('.supplement_info')
   = form.submit
-= link_to t('.to_tags'), tags_path

--- a/app/views/layouts/_footer.slim
+++ b/app/views/layouts/_footer.slim
@@ -13,4 +13,3 @@ ul.nav.nav-justified.fixed-bottom.bg-warning
     i.fas.fa-book-open
     i.fas.fa-plus
     = link_to t('.add_repertoire'), new_cooking_repertoire_path, class: 'nav-link text-dark'
-    

--- a/app/views/layouts/_footer.slim
+++ b/app/views/layouts/_footer.slim
@@ -5,10 +5,10 @@ ul.nav.nav-justified.nav-tabs.fixed-bottom.bg-light
   li class="nav-item border-right text-secondary #{'active text-warning' if current_page?(new_menu_path)}"
     i.fas.fa-calendar-minus
     i.fas.fa-pen
-    = link_to t('.decide_menu'), new_menu_path, class: 'nav-link text-secondary stretched-link'
+    = link_to t('.make_menu'), new_menu_path, class: 'nav-link text-secondary stretched-link'
   li class="nav-item border-right text-secondary #{'active text-warning' if current_page?(tags_path)}"
     i.fas.fa-book-open
-    = link_to t('.tags'), tags_path, class: 'nav-link text-secondary stretched-link'
+    = link_to t('.repertoires'), tags_path, class: 'nav-link text-secondary stretched-link'
   li class="nav-item text-secondary #{'active text-warning' if current_page?(new_cooking_repertoire_path)}"
     i.fas.fa-book-open
     i.fas.fa-plus

--- a/app/views/layouts/_footer.slim
+++ b/app/views/layouts/_footer.slim
@@ -1,15 +1,15 @@
-ul.nav.nav-justified.fixed-bottom.bg-warning
+ul.nav.nav-justified.nav-tabs.fixed-bottom.bg-warning
   li.nav-item.border-right
     i.fas.fa-calendar-minus
-    = link_to t('.menus'), menus_path, class: 'nav-link text-dark'
+    = link_to t('.menus'), menus_path, class: "nav-link text-dark #{'active' if current_page?(menus_path)}"
   li.nav-item.border-right
     i.fas.fa-calendar-minus
     i.fas.fa-pen
-    = link_to t('.decide_menu'), new_menu_path, class: 'nav-link text-dark'
+    = link_to t('.decide_menu'), new_menu_path, class: "nav-link text-dark #{'active' if current_page?(new_menu_path)}"
   li.nav-item.border-right
     i.fas.fa-book-open
-    = link_to t('.tags'), tags_path, class: 'nav-link text-dark'
+    = link_to t('.tags'), tags_path, class: "nav-link text-dark #{'active' if current_page?(tags_path)}"
   li.nav-item
     i.fas.fa-book-open
     i.fas.fa-plus
-    = link_to t('.add_repertoire'), new_cooking_repertoire_path, class: 'nav-link text-dark'
+    = link_to t('.add_repertoire'), new_cooking_repertoire_path, class: "nav-link text-dark #{'active' if current_page?(new_cooking_repertoire_path)}"

--- a/app/views/layouts/_footer.slim
+++ b/app/views/layouts/_footer.slim
@@ -1,15 +1,15 @@
-ul.nav.nav-justified.nav-tabs.fixed-bottom.bg-warning
-  li.nav-item.border-right
+ul.nav.nav-justified.nav-tabs.fixed-bottom.bg-light
+  li class="nav-item border-right text-secondary #{'active text-warning' if current_page?(menus_path)}"
     i.fas.fa-calendar-minus
-    = link_to t('.menus'), menus_path, class: "nav-link text-dark #{'active' if current_page?(menus_path)}"
-  li.nav-item.border-right
+    = link_to t('.menus'), menus_path, class: 'nav-link text-secondary stretched-link btn-ignore'
+  li class="nav-item border-right text-secondary #{'active text-warning' if current_page?(new_menu_path)}"
     i.fas.fa-calendar-minus
     i.fas.fa-pen
-    = link_to t('.decide_menu'), new_menu_path, class: "nav-link text-dark #{'active' if current_page?(new_menu_path)}"
-  li.nav-item.border-right
+    = link_to t('.decide_menu'), new_menu_path, class: 'nav-link text-secondary stretched-link'
+  li class="nav-item border-right text-secondary #{'active text-warning' if current_page?(tags_path)}"
     i.fas.fa-book-open
-    = link_to t('.tags'), tags_path, class: "nav-link text-dark #{'active' if current_page?(tags_path)}"
-  li.nav-item
+    = link_to t('.tags'), tags_path, class: 'nav-link text-secondary stretched-link'
+  li class="nav-item text-secondary #{'active text-warning' if current_page?(new_cooking_repertoire_path)}"
     i.fas.fa-book-open
     i.fas.fa-plus
-    = link_to t('.add_repertoire'), new_cooking_repertoire_path, class: "nav-link text-dark #{'active' if current_page?(new_cooking_repertoire_path)}"
+    = link_to t('.add_repertoire'), new_cooking_repertoire_path, class: 'nav-link text-secondary stretched-link'

--- a/app/views/layouts/_footer.slim
+++ b/app/views/layouts/_footer.slim
@@ -1,15 +1,16 @@
-ul.nav.nav-justified
-  li.nav-item
+ul.nav.nav-justified.fixed-bottom.bg-warning
+  li.nav-item.border-right
     i.fas.fa-calendar-minus
-    = link_to t('.menus'), menus_path, class: 'nav-link'
-  li.nav-item
+    = link_to t('.menus'), menus_path, class: 'nav-link text-dark'
+  li.nav-item.border-right
     i.fas.fa-calendar-minus
     i.fas.fa-pen
-    = link_to t('.decide_menu'), new_menu_path, class: 'nav-link'
-  li.nav-item
+    = link_to t('.decide_menu'), new_menu_path, class: 'nav-link text-dark'
+  li.nav-item.border-right
     i.fas.fa-book-open
-    = link_to t('.tags'), tags_path, class: 'nav-link'
+    = link_to t('.tags'), tags_path, class: 'nav-link text-dark'
   li.nav-item
     i.fas.fa-book-open
     i.fas.fa-plus
-    = link_to t('.add_repertoire'), new_cooking_repertoire_path, class: 'nav-link'
+    = link_to t('.add_repertoire'), new_cooking_repertoire_path, class: 'nav-link text-dark'
+    

--- a/app/views/layouts/_footer.slim
+++ b/app/views/layouts/_footer.slim
@@ -1,0 +1,15 @@
+ul.nav.nav-justified
+  li.nav-item
+    i.fas.fa-calendar-minus
+    = link_to t('.menus'), menus_path, class: 'nav-link'
+  li.nav-item
+    i.fas.fa-calendar-minus
+    i.fas.fa-pen
+    = link_to t('.decide_menu'), new_menu_path, class: 'nav-link'
+  li.nav-item
+    i.fas.fa-book-open
+    = link_to t('.tags'), tags_path, class: 'nav-link'
+  li.nav-item
+    i.fas.fa-book-open
+    i.fas.fa-plus
+    = link_to t('.add_repertoire'), new_cooking_repertoire_path, class: 'nav-link'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,3 +11,4 @@ html
     = stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body
     = yield
+    = render 'layouts/footer'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -3,6 +3,7 @@ html
   head
     title
       | TodaysDinner
+    meta name="viewport" content="width=device-width, initial-scale=1.0"
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'

--- a/app/views/menus/index.slim
+++ b/app/views/menus/index.slim
@@ -9,3 +9,9 @@ div = link_to t('.decide_menu'), new_menu_path
     - else
       = "#{tag.name}, "
 div = link_to t('.to_tags'), tags_path
+
+ul.nav.nav-justified
+  li.nav-item = link_to t('.menus'), menus_path, class: 'nav-link'
+  li.nav-item = link_to t('.decide_menu'), new_menu_path, class: 'nav-link'
+  li.nav-item = link_to t('.tags'), tags_path, class: 'nav-link'
+  li.nav-item = link_to t('.add_repertoire'), new_cooking_repertoire_path, class: 'nav-link'

--- a/app/views/menus/index.slim
+++ b/app/views/menus/index.slim
@@ -1,5 +1,4 @@
 = flash.notice
-div = link_to t('.decide_menu'), new_menu_path
 - @menus.each do |menu|
   div = l(menu.date)
   h3 = menu.cooking_repertoire.name
@@ -8,4 +7,3 @@ div = link_to t('.decide_menu'), new_menu_path
       = tag.name
     - else
       = "#{tag.name}, "
-div = link_to t('.to_tags'), tags_path

--- a/app/views/menus/index.slim
+++ b/app/views/menus/index.slim
@@ -11,7 +11,17 @@ div = link_to t('.decide_menu'), new_menu_path
 div = link_to t('.to_tags'), tags_path
 
 ul.nav.nav-justified
-  li.nav-item = link_to t('.menus'), menus_path, class: 'nav-link'
-  li.nav-item = link_to t('.decide_menu'), new_menu_path, class: 'nav-link'
-  li.nav-item = link_to t('.tags'), tags_path, class: 'nav-link'
-  li.nav-item = link_to t('.add_repertoire'), new_cooking_repertoire_path, class: 'nav-link'
+  li.nav-item
+    i.fas.fa-calendar-minus
+    = link_to t('.menus'), menus_path, class: 'nav-link'
+  li.nav-item
+    i.fas.fa-calendar-minus
+    i.fas.fa-pen
+    = link_to t('.decide_menu'), new_menu_path, class: 'nav-link'
+  li.nav-item
+    i.fas.fa-book-open
+    = link_to t('.tags'), tags_path, class: 'nav-link'
+  li.nav-item
+    i.fas.fa-book-open
+    i.fas.fa-plus
+    = link_to t('.add_repertoire'), new_cooking_repertoire_path, class: 'nav-link'

--- a/app/views/menus/index.slim
+++ b/app/views/menus/index.slim
@@ -9,19 +9,3 @@ div = link_to t('.decide_menu'), new_menu_path
     - else
       = "#{tag.name}, "
 div = link_to t('.to_tags'), tags_path
-
-ul.nav.nav-justified
-  li.nav-item
-    i.fas.fa-calendar-minus
-    = link_to t('.menus'), menus_path, class: 'nav-link'
-  li.nav-item
-    i.fas.fa-calendar-minus
-    i.fas.fa-pen
-    = link_to t('.decide_menu'), new_menu_path, class: 'nav-link'
-  li.nav-item
-    i.fas.fa-book-open
-    = link_to t('.tags'), tags_path, class: 'nav-link'
-  li.nav-item
-    i.fas.fa-book-open
-    i.fas.fa-plus
-    = link_to t('.add_repertoire'), new_cooking_repertoire_path, class: 'nav-link'

--- a/app/views/tags/index.slim
+++ b/app/views/tags/index.slim
@@ -1,6 +1,5 @@
 = flash.notice
 h1 = t('.title')
-div = link_to t('.new_registration'), new_cooking_repertoire_path
 - @tags.each do |tag|
   h2 = tag.name
   - if tag.cooking_repertoires.present?

--- a/config/locales/views/cooking_repertoires/ja.yml
+++ b/config/locales/views/cooking_repertoires/ja.yml
@@ -4,8 +4,6 @@ ja:
       title: 新規登録
     index:
       title: レパートリー一覧
-      new_registration: レパートリー名新規登録
-      to_tags: タグ一覧へ
     show: 
       title: レパートリーの詳細
       back_list: 一覧へ戻る
@@ -16,5 +14,4 @@ ja:
     edit:
       title: レパートリー名編集
     form:
-      to_tags: タグ一覧へ
       supplement_info: 複数選択可、3つまで

--- a/config/locales/views/layouts/ja.yml
+++ b/config/locales/views/layouts/ja.yml
@@ -2,6 +2,6 @@ ja:
   layouts:
     footer:
       menus: 献立
-      decide_menu: 献立作成
-      tags: レパートリー
+      make_menu: 献立作成
+      repertoires: レパートリー
       add_repertoire: レパートリー追加

--- a/config/locales/views/layouts/ja.yml
+++ b/config/locales/views/layouts/ja.yml
@@ -1,0 +1,7 @@
+ja:
+  layouts:
+    footer:
+      menus: 献立
+      decide_menu: 献立作成
+      tags: レパートリー
+      add_repertoire: レパートリー追加

--- a/config/locales/views/menus/ja.yml
+++ b/config/locales/views/menus/ja.yml
@@ -1,8 +1,10 @@
 ja:
   menus:
     index:
-      decide_menu: 献立を決める
-      to_tags: レパートリー一覧へ
+      menus: 献立
+      decide_menu: 献立作成
+      tags: レパートリー
+      add_repertoire: レパートリー追加
     new:
       one_day: 1日
       seven_days: 7日

--- a/config/locales/views/menus/ja.yml
+++ b/config/locales/views/menus/ja.yml
@@ -1,10 +1,5 @@
 ja:
   menus:
-    index:
-      menus: 献立
-      decide_menu: 献立作成
-      tags: レパートリー
-      add_repertoire: レパートリー追加
     new:
       one_day: 1日
       seven_days: 7日

--- a/config/locales/views/tags/ja.yml
+++ b/config/locales/views/tags/ja.yml
@@ -3,4 +3,3 @@ ja:
     index:
       title: レパートリー一覧
       no_repertoire_name: レパートリーはまだありません
-      new_registration: レパートリー新規登録

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "todays_dinner",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.13.0",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -778,6 +778,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@fortawesome/fontawesome-free@^5.13.0":
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.13.0.tgz#fcb113d1aca4b471b709e8c9c168674fbd6e06d9"
+  integrity sha512-xKOeQEl5O47GPZYIMToj6uuA2syyFlq9EMSl2ui0uytjY9xbe8XS0pexNWmxrdcCyNGyDmLyYw5FtKsalBUeOg==
+
 "@rails/actioncable@^6.0.0":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.0.2.tgz#bcba9bcd6ee09a47c6628336e07399a68ca87814"


### PR DESCRIPTION
closed #70 
## やったこと
- グローバルメニューを作成する
  - 献立一覧画面のフッターにグローバルメニューを作成する
    - 「献立」、「献立作成」、「レパートリー」、「レパートリー追加」の4つを作成する
    - グローバルメニューの文字の上にアイコンを作成する
  - 部分テンプレートにして全ての画面の下に配置されるようにする
    - 作成したグローバルメニューを部分テンプレートファイルにする
    - application.html.slimのbodyの一番下で部分テンプレートを呼び込む
  - スタイルを適用してグローバルメニューを固定する
    - グローバルメニューにスタイルを当ててスクロールしても固定で表示されるようにする
  - 現在のページがわかるように動的にactiveクラスを付与
- これまで使用していた不必要なリンクを削除する
  - 献立一覧画面の「レパートリー一覧へ」、「献立を決める」を削除
  - レパートリー一覧画面の「レパートリー新規登録」を削除
  - レパートリー新規登録画面の「タグ一覧へ」を削除

## 実行結果
**スマホで見た画面**
<img src="https://user-images.githubusercontent.com/62975075/82405539-2b96c480-9a9f-11ea-82fd-64381e4aa7f5.png" width="320px">

___

<img src="https://user-images.githubusercontent.com/62975075/82405547-2fc2e200-9a9f-11ea-80c4-5a37f2f5c68e.png" width="320px">

