### PR TITLE
レパートリー名の新規登録/編集のビューにスタイルを適用する

### DIFF
--- a/app/javascript/stylesheets/_form.scss
+++ b/app/javascript/stylesheets/_form.scss
@@ -1,7 +1,7 @@
 form {
   padding-top: 5rem;
 
-  .required::before{
+  .required::before {
     font-size: 0.8rem;
     content: "必須";
     color: white;

--- a/app/javascript/stylesheets/_form.scss
+++ b/app/javascript/stylesheets/_form.scss
@@ -1,0 +1,27 @@
+form {
+  padding-top: 5rem;
+
+  .required::before{
+    font-size: 0.8rem;
+    content: "必須";
+    color: white;
+    background-color: red;
+    padding: 0.3rem;
+    border-radius: 0.5rem;
+    margin-right: 0.2rem;
+  }
+
+  .required {
+    .field_with_errors {
+      display: inline-block;
+    }
+  }
+
+  .input-lg {
+    font-size: 1.5rem;
+  }
+
+  .font-size-lg{
+    font-size: 1.2rem;
+  }  
+}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,3 +1,4 @@
 @import '~bootstrap/scss/bootstrap';
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';
 @import './footer.scss';
+@import './form.scss';

--- a/app/views/cooking_repertoires/_form.slim
+++ b/app/views/cooking_repertoires/_form.slim
@@ -1,10 +1,15 @@
 = form_with model: cooking_repertoire, local: true do |form|
   - if cooking_repertoire.errors.any?
-    ul
-      - cooking_repertoire.errors.full_messages.each do |message|
-        li = message
-  .required = form.label :name
-  = form.text_field :name, required: true
-  .required = form.collection_check_boxes :tag_ids, tags, :id, :name
-  div = t('.supplement_info')
-  = form.submit
+    - cooking_repertoire.errors.full_messages.each do |message|
+      .alert.alert-danger = message
+  .form-group
+    .required = form.label :name
+    = form.text_field :name, class: 'form-control input-lg'
+  .form-group
+    .required.my-2 = t('.supplement_info')
+    = form.collection_check_boxes :tag_ids, tags, :id, :name do |b|
+      = b.label(class: 'form-control mb-3 font-size-lg') do
+        = b.check_box
+        = b.object.name
+  .form-group
+    = form.submit class: 'btn btn-lg btn-warning text-light form-control mb-3'

--- a/app/views/cooking_repertoires/_form.slim
+++ b/app/views/cooking_repertoires/_form.slim
@@ -9,7 +9,7 @@
     .required.my-2 = t('.supplement_info')
     = form.collection_check_boxes :tag_ids, tags, :id, :name do |b|
       = b.label(class: 'form-control mb-3 font-size-lg') do
-        = b.check_box
+        = b.check_box class: 'mr-2'
         = b.object.name
   .form-group
     = form.submit class: 'btn btn-lg btn-warning text-light form-control mb-3'

--- a/app/views/cooking_repertoires/edit.slim
+++ b/app/views/cooking_repertoires/edit.slim
@@ -1,2 +1,3 @@
-h1 = t('.title')
-= render 'form', cooking_repertoire: @cooking_repertoire, tags: @tags
+h4.py-3.text-center.bg-primary.text-light.fixed-top = t('.title')
+.container
+  = render 'form', cooking_repertoire: @cooking_repertoire, tags: @tags

--- a/app/views/cooking_repertoires/new.slim
+++ b/app/views/cooking_repertoires/new.slim
@@ -1,2 +1,3 @@
-h1 = t('.title')
-= render 'form', cooking_repertoire: @cooking_repertoire, tags: @tags
+h4.py-3.text-center.bg-primary.text-light.fixed-top = t('.title')
+.container
+  = render 'form', cooking_repertoire: @cooking_repertoire, tags: @tags

--- a/app/views/layouts/_footer.slim
+++ b/app/views/layouts/_footer.slim
@@ -9,7 +9,7 @@ ul.nav.nav-justified.nav-tabs.fixed-bottom.bg-light
   li class="nav-item border-right text-secondary #{'active text-warning' if current_page?(tags_path)}"
     i.fas.fa-book-open
     = link_to t('.repertoires'), tags_path, class: 'nav-link text-secondary stretched-link'
-  li class="nav-item text-secondary #{'active text-warning' if current_page?(new_cooking_repertoire_path)}"
+  li class="nav-item text-secondary #{'active text-warning' if current_page?(new_cooking_repertoire_path) || (request.path == '/cooking_repertoires')}"
     i.fas.fa-book-open
     i.fas.fa-plus
     = link_to t('.add_repertoire'), new_cooking_repertoire_path, class: 'nav-link text-secondary stretched-link'

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -7,7 +7,7 @@ ja:
     attributes:
       cooking_repertoire:
         id: ID
-        name: レパートリー名
+        name: 名前
         tag: タグ
       tag:
         delete: 削除

--- a/config/locales/views/cooking_repertoires/ja.yml
+++ b/config/locales/views/cooking_repertoires/ja.yml
@@ -1,7 +1,7 @@
 ja:
   cooking_repertoires:
     new:
-      title: 新規登録
+      title: レパートリー新規登録
     index:
       title: レパートリー一覧
     show: 
@@ -12,6 +12,6 @@ ja:
       edit: 編集
       delete: 削除
     edit:
-      title: レパートリー名編集
+      title: レパートリー編集
     form:
       supplement_info: 複数選択可、3つまで


### PR DESCRIPTION
closed #38 
## やったこと
- 翻訳の名称を変更する
- form(新規登録/編集)にスタイルを適用する(view)
  - bootstrapを用いてformにスタイルを適用する(slim)
  - scssファイルでfont-size等を調整するときpxではなくremを用いて記述する(scss)

**bootstrapのデフォルトstyle**
```
font-size: 16px;
line-height: 1.5;`
font-family: “Helvetica Neue”, Helvetica, Arial, sans-serif;
```
(参考記事: https://bootstrapcreative.com/bootstrap-text-sizes/)

## 実行画面
![スクリーンショット 2020-05-21 12 02 52](https://user-images.githubusercontent.com/62975075/82518805-2303c400-9b5b-11ea-8f04-6e33ed44d102.png)

____

![スクリーンショット 2020-05-21 12 03 03](https://user-images.githubusercontent.com/62975075/82518828-2f881c80-9b5b-11ea-90cb-ebb141ce7862.png)

___
![スクリーンショット 2020-05-21 12 03 24](https://user-images.githubusercontent.com/62975075/82518840-36169400-9b5b-11ea-98a7-1fba2a98f2a8.png)
___
![スクリーンショット 2020-05-21 12 03 31](https://user-images.githubusercontent.com/62975075/82518849-39aa1b00-9b5b-11ea-882c-aa3e87e37149.png)

**エラー画面**

____
![スクリーンショット 2020-05-21 12 03 13](https://user-images.githubusercontent.com/62975075/82518836-32830d00-9b5b-11ea-9faa-325f89f39507.png)

___
![スクリーンショット 2020-05-21 12 05 20](https://user-images.githubusercontent.com/62975075/82518930-652d0580-9b5b-11ea-829c-238a2227676c.png)

