### PR TITLE
詳細画面のスタイルを適用する

### DIFF
--- a/app/javascript/stylesheets/_show.scss
+++ b/app/javascript/stylesheets/_show.scss
@@ -1,0 +1,11 @@
+a, a:visited, a:focus, a:hover {
+  text-decoration: none;
+}
+
+.link {
+  bottom: 16px;
+}
+
+.right-link {
+  right: 8px;
+}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -2,3 +2,4 @@
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';
 @import './footer.scss';
 @import './form.scss';
+@import './show.scss';

--- a/app/views/cooking_repertoires/edit.slim
+++ b/app/views/cooking_repertoires/edit.slim
@@ -1,3 +1,6 @@
-h4.py-3.text-center.bg-primary.text-light.fixed-top = t('.title')
+h4.py-3.bg-warning.text-light.text-center.position-relative
+  = t('.title')
+  .d-flex.justify-content-between
+    = link_to t('.back'), cooking_repertoire_path(@cooking_repertoire), class: 'small position-absolute link'
 .container
   = render 'form', cooking_repertoire: @cooking_repertoire, tags: @tags

--- a/app/views/cooking_repertoires/show.slim
+++ b/app/views/cooking_repertoires/show.slim
@@ -1,24 +1,27 @@
 = flash.notice
-h1 = t('.title')
-li
-  = CookingRepertoire.human_attribute_name(:id) + t('.break')
-  = @cooking_repertoire.id
-li
-  = CookingRepertoire.human_attribute_name(:name) + t('.break')
-  = @cooking_repertoire.name
-li
-  = CookingRepertoire.human_attribute_name(:tag) + t('.break')
-  - @cooking_repertoire.cooking_repertoire_tags.each.with_index(1) do |cooking_repertoire_tag, index|
-    - if index == @cooking_repertoire.cooking_repertoire_tags.size
-      = cooking_repertoire_tag.tag.name
-    - else
-      = "#{cooking_repertoire_tag.tag.name}, "
-li
-  = CookingRepertoire.human_attribute_name(:created_at) + t('.break')
-  = @cooking_repertoire.created_at.to_s(:datetime_jp)
-li
-  = CookingRepertoire.human_attribute_name(:updated_at) + t('.break')
-  = @cooking_repertoire.updated_at.to_s(:datetime_jp)
-div = link_to t('.edit'), edit_cooking_repertoire_path
-div = link_to t('.delete'), cooking_repertoire_tags_path(@cooking_repertoire), method: :post, data: { confirm: t('.delete_confirmation', {name: @cooking_repertoire.name}) }
-div = link_to t('.back_list'), tags_path
+h4.py-3.bg-warning.text-light.text-center.position-relative
+  = t('.title')
+  .d-flex.justify-content-between
+    = link_to t('.back'), tags_path, class: 'small position-absolute link'
+    = link_to t('.edit'), edit_cooking_repertoire_path, class: 'small position-absolute link right-link'
+table.table.mt-5.border-bottom
+  tbody
+    tr
+      th = CookingRepertoire.human_attribute_name(:name)
+      td = @cooking_repertoire.name
+    tr
+      th = CookingRepertoire.human_attribute_name(:tag)
+      td
+        - @cooking_repertoire.cooking_repertoire_tags.each.with_index(1) do |cooking_repertoire_tag, index|
+          - if index == @cooking_repertoire.cooking_repertoire_tags.size
+            = cooking_repertoire_tag.tag.name
+          - else
+            = "#{cooking_repertoire_tag.tag.name}, "
+    tr
+      th = CookingRepertoire.human_attribute_name(:created_at)
+      td = @cooking_repertoire.created_at.to_s(:datetime_jp)
+    tr
+      th = CookingRepertoire.human_attribute_name(:updated_at)
+      td = @cooking_repertoire.updated_at.to_s(:datetime_jp)
+.container.text-center
+  = link_to t('.delete'), cooking_repertoire_tags_path(@cooking_repertoire), method: :post, data: { confirm: t('.delete_confirmation', {name: @cooking_repertoire.name}) }, class: 'btn btn-danger center-block'

--- a/config/locales/views/cooking_repertoires/ja.yml
+++ b/config/locales/views/cooking_repertoires/ja.yml
@@ -6,12 +6,13 @@ ja:
       title: レパートリー一覧
     show: 
       title: レパートリーの詳細
-      back_list: 一覧へ戻る
+      back: 〈 戻る
       delete_confirmation: レパートリー名「%{name}」を削除します。よろしいですか？
       break: ': '
       edit: 編集
       delete: 削除
     edit:
       title: レパートリー編集
+      back: 〈 戻る
     form:
       supplement_info: 複数選択可、3つまで


### PR DESCRIPTION
closed #40 
## やったこと
- レパートリー詳細画面のスタイルを適用する
  - bootstrapを用いて詳細画面にスタイルを適用する
    - 詳細の左の"<"はタグ一覧画面に戻る
    - tableで実装する
  - font-sizeはremを用いる
- 詳細画面に合わせて編集画面のスタイルを変更する

## 実行結果
![スクリーンショット 2020-05-21 16 47 11](https://user-images.githubusercontent.com/62975075/82537346-df25b480-9b84-11ea-8c8e-7c5ae065fc48.png)

___
**変更前**
![スクリーンショット 2020-05-21 12 03 24](https://user-images.githubusercontent.com/62975075/82537450-02e8fa80-9b85-11ea-9b38-5f115b7278c9.png)
___
**変更後**
![スクリーンショット 2020-05-21 16 56 04](https://user-images.githubusercontent.com/62975075/82537359-e351d200-9b84-11ea-884d-054b7059d0c3.png)
