### PR TITLE
タグの一覧画面のスタイルの適用

### DIFF
--- a/app/javascript/stylesheets/_footer.scss
+++ b/app/javascript/stylesheets/_footer.scss
@@ -1,5 +1,6 @@
 body {
-  padding-bottom: 70px;
+  padding-top: 60px;
+  padding-bottom: 86px;
 }
 
 .nav-item{

--- a/app/javascript/stylesheets/_form.scss
+++ b/app/javascript/stylesheets/_form.scss
@@ -1,6 +1,4 @@
-form {
-  padding-top: 5rem;
-
+form {  
   .required::before {
     font-size: 0.8rem;
     content: "必須";

--- a/app/javascript/stylesheets/_index.scss
+++ b/app/javascript/stylesheets/_index.scss
@@ -1,0 +1,5 @@
+.card:before {
+  content: "";
+  display: block;
+  padding-top: 80%;
+}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -3,3 +3,4 @@
 @import './footer.scss';
 @import './form.scss';
 @import './show.scss';
+@import './index.scss';

--- a/app/views/cooking_repertoires/edit.slim
+++ b/app/views/cooking_repertoires/edit.slim
@@ -1,6 +1,6 @@
-h4.py-3.bg-warning.text-light.text-center.position-relative
+h4.py-3.bg-warning.text-light.text-center.fixed-top
   = t('.title')
   .d-flex.justify-content-between
     = link_to t('.back'), cooking_repertoire_path(@cooking_repertoire), class: 'small position-absolute link'
-.container
+.container.mt-3
   = render 'form', cooking_repertoire: @cooking_repertoire, tags: @tags

--- a/app/views/cooking_repertoires/new.slim
+++ b/app/views/cooking_repertoires/new.slim
@@ -1,3 +1,3 @@
 h4.py-3.text-center.bg-primary.text-light.fixed-top = t('.title')
-.container
+.container.mt-3
   = render 'form', cooking_repertoire: @cooking_repertoire, tags: @tags

--- a/app/views/cooking_repertoires/show.slim
+++ b/app/views/cooking_repertoires/show.slim
@@ -1,5 +1,4 @@
-= flash.notice
-h4.py-3.bg-warning.text-light.text-center.position-relative
+h4.py-3.bg-warning.text-light.text-center.fixed-top
   = t('.title')
   .d-flex.justify-content-between
     = link_to t('.back'), tags_path, class: 'small position-absolute link'

--- a/app/views/tags/index.slim
+++ b/app/views/tags/index.slim
@@ -1,10 +1,18 @@
-= flash.notice
-h1 = t('.title')
+h4.py-3.bg-warning.text-light.text-center.fixed-top
+  = t('.title')
+.container
+  - if flash.notice.present? 
+    .alert.alert-success.my-2 = flash.notice
 - @tags.each do |tag|
-  h2 = tag.name
-  - if tag.cooking_repertoires.present?
-    - tag.cooking_repertoires.each do |cooking_repertoire|
-      - unless cooking_repertoire.tags.exists?(name: t('activerecord.attributes.tag.delete'))
-        li = link_to cooking_repertoire.name, cooking_repertoire_path(cooking_repertoire.id)
-  - else
-    = t('.no_repertoire_name')
+  .container
+    h5.border-bottom.py-3 = tag.name
+  .container.d-flex.flex-wrap
+    - if tag.cooking_repertoires.present?
+      - tag.cooking_repertoires.each do |cooking_repertoire|
+        - unless cooking_repertoire.tags.exists?(name: t('activerecord.attributes.tag.delete'))
+          .col-6.col-md-3.p-2
+            .card
+              .card-body.w-100.h-100.position-absolute
+                = link_to cooking_repertoire.name, cooking_repertoire_path(cooking_repertoire.id), class: 'stretched-link '
+    - else
+      = t('.no_repertoire_name')


### PR DESCRIPTION
closed #39 
## やったこと
- bodyにタイトル分のpaddingを追加する
- スマホサイズに合わせてpadding-bottomを変更する
- タイトルを固定する
  - 固定することによるformのズレを修正する
- タグーの一覧画面のスタイルを適用する
  - bootstrapを用いてレパートリー一覧画面にスタイルを適用する
  - font-sizeはremを用いる

## 実行画面
![スクリーンショット 2020-05-22 10 52 01](https://user-images.githubusercontent.com/62975075/82623433-265e8480-9c1b-11ea-8279-274894a12362.png)

___
![スクリーンショット 2020-05-22 10 52 07](https://user-images.githubusercontent.com/62975075/82623437-29597500-9c1b-11ea-9480-7d97c41a795b.png)

**フラッシュメッセージ**
![スクリーンショット 2020-05-22 11 48 12](https://user-images.githubusercontent.com/62975075/82626231-3af24b00-9c22-11ea-8c2a-340253ecd873.png)


**修正後**
![スクリーンショット 2020-05-22 11 48 20](https://user-images.githubusercontent.com/62975075/82626214-32017980-9c22-11ea-8850-45ecc2989712.png)

___
![スクリーンショット 2020-05-22 11 48 30](https://user-images.githubusercontent.com/62975075/82626223-362d9700-9c22-11ea-9ef6-8fc58c8e5d86.png)

