### PR TITLE
献立作成画面のスタイルを適用する

### DIFF
--- a/app/views/menus/new.slim
+++ b/app/views/menus/new.slim
@@ -1,17 +1,25 @@
 h4.py-3.text-center.bg-primary.text-light.fixed-top = t('.title')
-= flash.notice
-= form_with model: @menu, local: true do |form|
-  div = form.label :date
-  div = form.date_field :date, value: Date.today
-  div = form.label :period
-  div = form.select :period, options_for_select(periods)
-  div = form.label :not_duplicate_day
-  div = form.select :not_duplicate_day,  options_for_select(not_duplicate_days)
-  - @tags.each do |tag|
-    - if MenuCandidateTag.where(tag_id: tag).exists? || MenuCandidateTag.all.empty?
-      = check_box_tag 'tag_candidates[tags][]', tag.id, checked = true, id: tag.id
-    - else
-      = check_box_tag 'tag_candidates[tags][]', tag.id, checked = false, id: tag.id
-    = label_tag :tag, tag.name, for: tag.id
-  p = t('.menus_are_created_from_repertoires_that_include_checked_tags')
-  div = form.submit
+.container.pt-3
+  - if flash.notice.present? 
+    .alert.alert-danger = flash.notice
+  = form_with model: @menu, local: true do |form|
+    .form-group
+      = form.label :date
+      = form.date_field :date, value: Date.today, class: 'form-control'
+    .form-group
+      = form.label :period
+      = form.select :period, options_for_select(periods), {}, class: 'form-control'
+    .form-group
+      = form.label :not_duplicate_day
+      = form.select :not_duplicate_day, options_for_select(not_duplicate_days), {}, class: 'form-control'
+    .form-group
+      p = t('.menus_are_created_from_repertoires_that_include_checked_tags')
+      - @tags.each do |tag|
+        .form-control.mb-3.font-size-lg
+          - if MenuCandidateTag.where(tag_id: tag).exists? || MenuCandidateTag.all.empty?
+            = check_box_tag 'tag_candidates[tags][]', tag.id, checked = true, id: tag.id, class: 'mr-2'
+          - else
+            = check_box_tag 'tag_candidates[tags][]', tag.id, checked = false, id: tag.id, class: 'mr-2'
+          = label_tag :tag, tag.name, for: tag.id
+    .form-group
+      = form.submit class: 'btn btn-lg btn-warning text-light form-control mb-3'

--- a/app/views/menus/new.slim
+++ b/app/views/menus/new.slim
@@ -1,3 +1,4 @@
+h4.py-3.text-center.bg-primary.text-light.fixed-top = t('.title')
 = flash.notice
 = form_with model: @menu, local: true do |form|
   div = form.label :date

--- a/config/locales/views/menus/ja.yml
+++ b/config/locales/views/menus/ja.yml
@@ -6,3 +6,4 @@ ja:
       thirty_days: 30日
       day: '%{one_day}日'
       menus_are_created_from_repertoires_that_include_checked_tags: ※チェックがついているタグを含むレパートリーから献立が作成されます
+      title: 献立作成


### PR DESCRIPTION
closed #69 
## やったこと
- 献立新規作成画面にタイトルを追加する
- 献立新規作成画面のスタイルを適用する
  - bootstrapを用いてレパートリー一覧画面にスタイルを適用する
  - font-sizeはremを用いる
## 実行結果
![スクリーンショット 2020-05-22 13 37 25](https://user-images.githubusercontent.com/62975075/82632271-b78d2580-9c32-11ea-97fd-4df2aa680296.png)
![スクリーンショット 2020-05-22 13 33 34](https://user-images.githubusercontent.com/62975075/82632281-be1b9d00-9c32-11ea-9eba-772e508deaf6.png)

**作成失敗時**
![スクリーンショット 2020-05-22 13 37 51](https://user-images.githubusercontent.com/62975075/82632295-c673d800-9c32-11ea-9a29-1f4b856ab8b0.png)

