### PR TITLE
献立一覧画面のスタイルの適用

### DIFF
--- a/app/javascript/stylesheets/_footer.scss
+++ b/app/javascript/stylesheets/_footer.scss
@@ -5,7 +5,7 @@ body {
 
 .nav-item{
   position: relative;
-  padding: 0.5rem;
+  padding-top: 8px;
   .nav-link {
     font-size: 0.5rem;
     border: none;

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -4,3 +4,4 @@
 @import './form.scss';
 @import './show.scss';
 @import './index.scss';
+@import './menus/index.scss';

--- a/app/javascript/stylesheets/menus/_index.scss
+++ b/app/javascript/stylesheets/menus/_index.scss
@@ -1,0 +1,3 @@
+.table-striped tbody tr:nth-of-type(odd) {
+  background-color: #FFE187;
+}

--- a/app/views/menus/index.slim
+++ b/app/views/menus/index.slim
@@ -1,4 +1,7 @@
-= flash.notice
+h4.py-3.text-center.bg-primary.text-light.fixed-top = t('.title')
+.container.pt-3
+  - if flash.notice.present? 
+    .alert.alert-success = flash.notice
 - @menus.each do |menu|
   div = l(menu.date)
   h3 = menu.cooking_repertoire.name

--- a/app/views/menus/index.slim
+++ b/app/views/menus/index.slim
@@ -1,12 +1,14 @@
-h4.py-3.text-center.bg-primary.text-light.fixed-top = t('.title')
-.container.pt-3
-  - if flash.notice.present? 
+h4.py-3.text-center.bg-warning.text-light.fixed-top = t('.title')
+- if flash.notice.present? 
+  .container.pt-3
     .alert.alert-success = flash.notice
-- @menus.each do |menu|
-  div = l(menu.date)
-  h3 = menu.cooking_repertoire.name
-  - menu.cooking_repertoire.tags.each.with_index(1) do |tag, index|
-    - if index == menu.cooking_repertoire.tags.size
-      = tag.name
-    - else
-      = "#{tag.name}, "
+table.table.table-striped
+  thead
+    tr.bg-light
+      th = t('.date')
+      th = t('.staple_food')
+  tbody
+    - @menus.each do |menu|
+      tr
+        td = l menu.date, format: :short
+        td = menu.cooking_repertoire.name

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -25,3 +25,4 @@ ja:
   time:
     formats:
       default: '%Y/%m/%d'
+      short: '%m/%d'

--- a/config/locales/views/menus/ja.yml
+++ b/config/locales/views/menus/ja.yml
@@ -2,6 +2,8 @@ ja:
   menus:
     index:
       title: 献立
+      date: 日付
+      staple_food: 主食
     new:
       one_day: 1日
       seven_days: 7日

--- a/config/locales/views/menus/ja.yml
+++ b/config/locales/views/menus/ja.yml
@@ -1,5 +1,7 @@
 ja:
   menus:
+    index:
+      title: 献立
     new:
       one_day: 1日
       seven_days: 7日


### PR DESCRIPTION
closed #68 
## やったこと
- 献立一覧画面にタイトルをつける
- スタイルを適用する
  - bootstrapを用いてレパートリー一覧画面にスタイルを適用する
  - font-sizeはremを用いる
- グローバルメニューの文字が綺麗に収まるように修正
## 実行画面
![スクリーンショット 2020-05-22 17 04 20](https://user-images.githubusercontent.com/62975075/82645767-65f29400-9c4e-11ea-988c-9bbfefdaf784.png)

**一日作成**
![スクリーンショット 2020-05-22 17 04 49](https://user-images.githubusercontent.com/62975075/82645788-6c810b80-9c4e-11ea-9e93-3b47e4ea4e89.png)

**複数日作成**
![スクリーンショット 2020-05-22 17 04 59](https://user-images.githubusercontent.com/62975075/82645815-7276ec80-9c4e-11ea-9dc6-4857f437f44e.png)

**修正後グローバルメニュー**
![スクリーンショット 2020-05-22 17 06 16](https://user-images.githubusercontent.com/62975075/82645889-93d7d880-9c4e-11ea-9c3c-3c6b445c760e.png)

